### PR TITLE
use max msg length for ext packet

### DIFF
--- a/components/usbd-ccid/src/constants.rs
+++ b/components/usbd-ccid/src/constants.rs
@@ -10,11 +10,7 @@ pub type PACKET_SIZE_TYPE = consts::U512;
 #[cfg(not(feature = "highspeed-usb"))]
 pub type PACKET_SIZE_TYPE = consts::U64;
 
-// size??
-pub type EXT_PACKET_SIZE_TYPE = consts::U384;
-
 pub const PACKET_SIZE: usize = PACKET_SIZE_TYPE::USIZE;
-pub const EXT_PACKET_SIZE: usize = EXT_PACKET_SIZE_TYPE::USIZE;
 
 pub const CLASS_CCID: u8 = 0x0B;
 pub const SUBCLASS_NONE: u8 = 0x0;

--- a/components/usbd-ccid/src/types/packet.rs
+++ b/components/usbd-ccid/src/types/packet.rs
@@ -4,7 +4,7 @@ use crate::constants::*;
 
 
 pub type RawPacket = heapless::ByteBuf<PACKET_SIZE_TYPE>;
-pub type ExtPacket = heapless::ByteBuf<EXT_PACKET_SIZE_TYPE>;
+pub type ExtPacket = heapless::ByteBuf<MAX_MSG_LENGTH_TYPE>;
 
 pub trait RawPacketExt {
     fn packet_len(&self) -> usize;
@@ -47,7 +47,7 @@ pub trait PacketWithData: Packet {
         // let len = u32::from_le_bytes(self[1..5].try_into().unwrap()) as usize;
         let declared_len =
             u32::from_le_bytes(self[1..5].try_into().unwrap()) as usize;
-        let len = core::cmp::min(EXT_PACKET_SIZE - 10, declared_len);
+        let len = core::cmp::min(MAX_MSG_LENGTH - 10, declared_len);
         // hprintln!("delcared = {}, len = {}", declared_len, len).ok();
         &self[10..][..len]
     }


### PR DESCRIPTION
I was sending a large APDU containing a certificate in the payload and noticed it was getting cropped at around 384 bytes (`EXT_PACKET_SIZE`).  I think the max message length should be used instead?