### PR TITLE
Add RTT logging flusher, semihosting no longer default

### DIFF
--- a/components/ctap-types/src/webauthn.rs
+++ b/components/ctap-types/src/webauthn.rs
@@ -34,8 +34,8 @@ where
         Ok(string) => {
             Ok(Some(string))
         },
-        Err(err) => {
-            info_now!("skipping field: {:?}", err);
+        Err(_err) => {
+            info_now!("skipping field: {:?}", _err);
             Ok(None)
         }
     }

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -16,11 +16,12 @@ path = "src/main.rs"
 
 [dependencies]
 lpc55-rtic = "0.5.5"
-cortex-m-semihosting = "0.3.5"
+cortex-m-semihosting = {version = "0.3.5", optional = true }
 delog = "0.1.1"
 heapless = "0.6"
 interchange = "0.1.0"
 nb = "1"
+rtt-target = { version = "0.3", optional = true, features = ["cortex-m"] }
 trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main", features = ["clients-4"] }
 usb-device = "0.2.3"
 # usbd-hid = { version = "0.4.5", optional = true }
@@ -57,13 +58,16 @@ littlefs2 = "0.2.1"
 [features]
 default = []
 
-develop = ["no-encrypted-storage", "no-buttons"]
+develop = ["no-encrypted-storage", "no-buttons", "no-reset-time-window"]
 
 # Do not use encryption for the filesystem
 no-encrypted-storage = []
 
 # Use to auto-succeed every user presence check
 no-buttons = ["board/no-buttons"]
+
+# Allow resetting FIDO authenticator (and possibly others) even after 10s uptime
+no-reset-time-window = ["fido-authenticator/disable-reset-time-window"]
 
 # Format filesystem anyway
 format-filesystem = []
@@ -72,6 +76,8 @@ board-lpcxpresso55 = ["board/board-lpcxpresso55"]
 board-okdoe1 = ["board/board-okdoe1", "board-lpcxpresso55", "usbfs-peripheral"]
 board-solov2 = ["board/board-solov2"]
 
+log-rtt = ["rtt-target"]
+log-semihosting = ["cortex-m-semihosting"]
 log-serial = []
 
 highspeed = []

--- a/runners/lpc55/Makefile
+++ b/runners/lpc55/Makefile
@@ -1,4 +1,4 @@
-FEATURES := board-lpcxpresso55,no-encrypted-storage,no-buttons
+FEATURES := board-lpcxpresso55,develop
 
 build-dev:
 	cargo build --release --features $(FEATURES)

--- a/runners/lpc55/README.md
+++ b/runners/lpc55/README.md
@@ -1,0 +1,16 @@
+# LPC55 runner
+
+The entire firmware that runs all the things.
+
+
+### Logging
+
+The easy + fast way to log is to use the `log-rtt` feature.
+Listening on port `19021` (e.g. via `netcat localhost 19021`) outputs the RTT message output
+from `JLinkGDBServer -strict -device LPC55S69 -if SWD -vd`.
+
+The slower alternative (although not so bad due to `delog` bundling) is to use the `log-semihosting` feature.
+Both at once does not work, neither does `log-serial`.
+
+Additionally, logging features need to be turned on.
+An example invocation: `cargo run --release --features board-lpcxpresso55,develop,log-rtt,fido-authenticator/log-all` 


### PR DESCRIPTION
To have logs as before use `log-semihosting`.

Recommended: use `log-rtt` instead, and listen on `localhost:19021` for the RTT messages.