### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ jobs:
           target: thumbv8m.main-none-eabi
           override: true
           components: llvm-tools-preview
-      - name: Build
-        run: cargo build --release --features ${{ matrix.board }}
       # Use precompiled binutils
       - name: cargo install cargo-binutils
         uses: actions-rs/install@v0.1
@@ -56,8 +54,14 @@ jobs:
           crate: flip-link
           version: latest
           use-tool-cache: true
+      - name: Build
+        run: |
+          unset RUSTFLAGS
+          cargo build --release --features ${{ matrix.board }}
       - name: Size
-        run: cargo size --release --features ${{ matrix.board }}
+        run: |
+          unset RUSTFLAGS
+          cargo size --release --features ${{ matrix.board }}
 
   build-pc:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Found sneaky issue where RUSTFLAGS is somehow set to an empty string, and causes any config from `.cargo/config` to get overwritten.  You can see in previous builds that zero sized binaries were being made.

Also moved cargo installs before build, since flip-link is used for build.  Wasn't noticed before since it was overwritten.