### PR TITLE
Make usbd-ccid generic to avoid apdu-dispatch dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ bacon:
 run-dev:
 	make -C $(RUNNER) run-dev
 
+jlink:
+	scripts/bump-jlink
+	JLinkGDBServer -strict -device LPC55S69 -if SWD -vd
+
 mount-fs:
 	scripts/fuse-bee
 

--- a/components/usbd-ccid/Cargo.toml
+++ b/components/usbd-ccid/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-apdu-dispatch = { git = "https://github.com/solokeys/apdu-dispatch", branch = "main" }
 delog = "0.1.0"
 embedded-time = "0.10.1"
 heapless = "0.6"

--- a/components/usbd-ccid/src/types.rs
+++ b/components/usbd-ccid/src/types.rs
@@ -4,7 +4,7 @@ use embedded_time::duration::Milliseconds;
 pub mod packet;
 pub mod tlv;
 
-pub type MessageBuffer = apdu_dispatch::interchanges::Data;
+// pub type MessageBuffer = apdu_dispatch::interchanges::Data;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ClassRequest {

--- a/runners/lpc55/src/types/usb.rs
+++ b/runners/lpc55/src/types/usb.rs
@@ -6,7 +6,11 @@ pub type EnabledUsbPeripheral = hal::peripherals::usbhs::EnabledUsbhsDevice;
 #[cfg(feature = "usbfs-peripheral")]
 pub type EnabledUsbPeripheral = hal::peripherals::usbfs::EnabledUsbfsDevice;
 
-pub type CcidClass = usbd_ccid::Ccid<UsbBus<EnabledUsbPeripheral>>;
+pub type CcidClass = usbd_ccid::Ccid<
+    UsbBus<EnabledUsbPeripheral>,
+    apdu_dispatch::interchanges::Contact,
+    apdu_dispatch::interchanges::Size,
+>;
 pub type CtapHidClass = usbd_ctaphid::CtapHid<'static, UsbBus<EnabledUsbPeripheral>>;
 // pub type KeyboardClass = usbd_hid::hid_class::HIDClass<'static, UsbBus<EnabledUsbPeripheral>>;
 pub type SerialClass = usbd_serial::SerialPort<'static, UsbBus<EnabledUsbPeripheral>>;
@@ -29,8 +33,8 @@ impl UsbClasses {
         self.ctaphid.check_for_app_response();
         self.ccid.check_for_app_response();
         self.usbd.poll(&mut [
-            &mut self.ccid, 
-            &mut self.ctaphid, 
+            &mut self.ccid,
+            &mut self.ctaphid,
             &mut self.serial,
         ]);
     }


### PR DESCRIPTION
As seen in the modification of the LPC55 runner, making usbd-ccid more generic is painless.
In turn, the `apdu-dispatch` dependency can be removed.