### PR TITLE
Portable / Nonportable Trussed apps abstraction

### DIFF
--- a/components/ctaphid-dispatch/src/dispatch.rs
+++ b/components/ctaphid-dispatch/src/dispatch.rs
@@ -68,7 +68,7 @@ impl Dispatch {
     #[inline(never)]
     pub fn poll<'a>(
         &mut self,
-        apps: &'a mut [&'a mut dyn App],
+        apps: &mut [&'a mut dyn App],
     ) -> bool {
         let maybe_request = self.responder.take_request();
         if let Some((command, message)) = maybe_request {

--- a/components/provisioner-app/Cargo.toml
+++ b/components/provisioner-app/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "provisioner-app"
+version = "0.1.0"
+authors = ["Conor Patrick <conor@solokeys.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+apdu-dispatch = { git = "https://github.com/solokeys/apdu-dispatch", branch = "main" }
+delog = "0.1.1"
+heapless = "0.6"
+heapless-bytes = "0.2.0"
+lpc55-hal = { version = "0.2.1", features = ["littlefs", "rtic-peripherals"] }
+littlefs2 = "0.2.2"
+trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main" }
+
+[dependencies.nisty]
+version = "0.1.0-alpha.5"
+features = ["asn1-der", "cose"]
+
+[dependencies.salty]
+git = "https://github.com/ycrypto/salty"
+branch = "main"
+features = ["cose"]
+
+[features]
+log-all = []
+log-none = []
+log-info = []
+log-debug = []
+log-warn = []
+log-error = []
+
+

--- a/components/provisioner-app/src/lib.rs
+++ b/components/provisioner-app/src/lib.rs
@@ -1,0 +1,407 @@
+//! # Solo 2 provisioner app
+//!
+//! This is a highly *non-portable* Trussed app.
+//!
+//! It allows injecting arbitrary binary files at arbitrary paths, e.g., to inject FIDO batch
+//! attestation keys.
+//! It allows generating Trussed device attestation keys and obtaining their public keys,
+//! to then generate and inject attn certs from a given root or intermedidate CA.
+//!
+//! See `solo2-cli` for usage.
+#![no_std]
+
+#[macro_use]
+extern crate delog;
+generate_macros!();
+
+use trussed::types::LfsStorage;
+
+pub const FILESYSTEM_BOUNDARY: usize = 0x8_0000;
+
+use littlefs2::path::{PathBuf};
+use trussed::store::{self, Store};
+use trussed::{
+    syscall,
+    Client as TrussedClient,
+    key::{Kind as KeyKind, Key, Flags},
+};
+use heapless_bytes::Bytes;
+use apdu_dispatch::iso7816::{Status, Instruction};
+use apdu_dispatch::app::Result as ResponseResult;
+use apdu_dispatch::types::{Command, response, command};
+
+use lpc55_hal as hal;
+
+//
+const SOLO_PROVISIONER_AID: [u8; 9] = [ 0xA0, 0x00, 0x00, 0x08, 0x47, 0x01, 0x00, 0x00, 0x01];
+
+const TESTER_FILENAME_ID: [u8; 2] = [0xe1,0x01];
+const TESTER_FILE_ID: [u8; 2] = [0xe1,0x02];
+
+const WRITE_FILE_INS: u8 = 0xbf;
+
+const REFORMAT_FS_INS: u8 = 0xbd;
+const GET_UUID_INS: u8 = 0x62;
+
+const GENERATE_P256_ATTESTATION: u8 = 0xbc;
+const GENERATE_ED255_ATTESTATION: u8 = 0xbb;
+
+const SAVE_P256_ATTESTATION_CERT: u8 = 0xba;
+const SAVE_ED255_ATTESTATION_CERT: u8 = 0xb9;
+#[cfg(feature = "test-attestation")]
+const TEST_ATTESTATION: u8 = 0xb8;
+
+#[cfg(feature = "test-attestation")]
+#[derive(Copy,Clone)]
+enum TestAttestationP1 {
+    P256Sign = 0,
+    P256Cert = 1,
+    Ed255Sign= 2,
+    Ed255Cert= 3,
+}
+
+
+const FILENAME_P256_SECRET: &'static [u8] = b"/attn/sec/01";
+const FILENAME_ED255_SECRET: &'static [u8] = b"/attn/sec/02";
+
+const FILENAME_P256_CERT: &'static [u8] = b"/attn/x5c/01";
+const FILENAME_ED255_CERT: &'static [u8] = b"/attn/x5c/02";
+
+
+
+enum SelectedBuffer {
+    Filename,
+    File,
+}
+
+pub struct Provisioner<S, FS, T>
+where S: Store,
+      FS: 'static + LfsStorage,
+      T: TrussedClient,
+{
+    trussed: T,
+
+    selected_buffer: SelectedBuffer,
+    buffer_filename: Bytes<heapless::consts::U128>,
+    buffer_file_contents: Bytes<heapless::consts::U8192>,
+
+    store: S,
+    stolen_filesystem: &'static mut FS,
+    #[allow(dead_code)]
+    is_passive: bool,
+}
+
+impl<S, FS, T> Provisioner<S, FS, T>
+where S: Store,
+      FS: 'static + LfsStorage,
+      T: TrussedClient,
+{
+    pub fn new(
+        trussed: T,
+        store: S,
+        stolen_filesystem: &'static mut FS,
+        is_passive: bool,
+    ) -> Provisioner<S, FS, T> {
+
+
+        return Self {
+            trussed,
+
+            selected_buffer: SelectedBuffer::Filename,
+            buffer_filename: Bytes::new(),
+            buffer_file_contents: Bytes::new(),
+            store,
+            stolen_filesystem,
+            is_passive,
+        }
+    }
+
+    fn handle(&mut self, command: &Command, reply: &mut response::Data) -> ResponseResult {
+
+        match command.instruction() {
+            Instruction::Select => self.select(command, reply),
+            Instruction::WriteBinary => {
+                let _offset: u16 = ((command.p1 as u16) << 8) | command.p2 as u16;
+                match self.selected_buffer {
+                    SelectedBuffer::Filename => self.buffer_filename.extend_from_slice(command.data()).unwrap(),
+                    SelectedBuffer::File => self.buffer_file_contents.extend_from_slice(command.data()).unwrap(),
+                };
+                Ok(())
+            }
+            Instruction::Unknown(ins) => {
+                match ins {
+                    REFORMAT_FS_INS => {
+                        // Provide a method to reset the FS.
+                        info!("Reformatting the FS..");
+                        littlefs2::fs::Filesystem::format(self.stolen_filesystem)
+                            .map_err(|_| Status::NotEnoughMemory)?;
+                        Ok(())
+                    }
+                    WRITE_FILE_INS => {
+                        if self.buffer_file_contents.len() == 0 || self.buffer_filename.len() == 0 {
+                            Err(Status::IncorrectDataParameter)
+                        } else {
+                            // self.buffer_filename.push(0);
+                            let _filename = unsafe{ core::str::from_utf8_unchecked(self.buffer_filename.as_slice()) };
+                            info!("writing file {} {} bytes", _filename, self.buffer_file_contents.len());
+                            // logging::dump_hex(&self.buffer_file_contents, self.buffer_file_contents.len());
+
+                            let res = store::store(
+                                self.store,
+                                trussed::types::Location::Internal,
+                                &PathBuf::from(self.buffer_filename.as_slice()),
+                                &self.buffer_file_contents
+                            );
+                            self.buffer_file_contents.clear();
+                            self.buffer_filename.clear();
+                            if !res.is_ok() {
+                                info!("failed writing file!");
+                                Err(Status::NotEnoughMemory)
+                            } else {
+                                info!("wrote file");
+                                Ok(())
+                            }
+                        }
+                    }
+                    GENERATE_P256_ATTESTATION => {
+                        info!("GENERATE_P256_ATTESTATION");
+                        let mut seed = [0u8; 32];
+                        seed.copy_from_slice(
+                            &syscall!(self.trussed.random_bytes(32)).bytes.as_slice()
+                        );
+
+                        let serialized_key = Key {
+                            flags: Flags::LOCAL | Flags::SENSITIVE,
+                            kind: KeyKind::P256,
+                            material: Bytes::try_from_slice(&seed).unwrap(),
+                        };
+
+                        let serialized_bytes = serialized_key.serialize();
+
+                        store::store(
+                            self.store,
+                            trussed::types::Location::Internal,
+                            &PathBuf::from(FILENAME_P256_SECRET),
+                            &serialized_bytes
+                        ).map_err(|_| Status::NotEnoughMemory)?;
+                        info!("stored to {}", core::str::from_utf8(FILENAME_P256_SECRET).unwrap());
+
+                        let keypair = nisty::Keypair::generate_patiently(&seed);
+
+                        reply.extend_from_slice(keypair.public.as_bytes()).unwrap();
+                        Ok(())
+                    }
+                    GENERATE_ED255_ATTESTATION => {
+
+                        info!("GENERATE_ED255_ATTESTATION");
+                        let mut seed = [0u8; 32];
+                        seed.copy_from_slice(
+                            &syscall!(self.trussed.random_bytes(32)).bytes.as_slice()
+                        );
+
+                        let serialized_key = Key {
+                            flags: Flags::LOCAL | Flags::SENSITIVE,
+                            kind: KeyKind::Ed255,
+                            material: Bytes::try_from_slice(&seed).unwrap(),
+                        };
+
+                        // let serialized_key = Key::try_deserialize(&seed[..])
+                            // .map_err(|_| Status::WrongLength)?;
+
+                        let serialized_bytes = serialized_key.serialize();
+
+                        store::store(
+                            self.store,
+                            trussed::types::Location::Internal,
+                            &PathBuf::from(FILENAME_ED255_SECRET),
+                            &serialized_bytes
+                        ).map_err(|_| Status::NotEnoughMemory)?;
+
+                        let keypair = salty::Keypair::from(&seed);
+
+                        reply.extend_from_slice(keypair.public.as_bytes()).unwrap();
+                        Ok(())
+                    },
+
+                    SAVE_P256_ATTESTATION_CERT => {
+                        let secret_path = PathBuf::from(FILENAME_P256_SECRET);
+                        if !secret_path.exists(&self.store.ifs()) {
+                            Err(Status::IncorrectDataParameter)
+                        } else if command.data().len() < 100 {
+                            // Assuming certs will always be >100 bytes
+                            Err(Status::IncorrectDataParameter)
+                        } else {
+                            info!("saving P256 CERT, {} bytes", command.data().len());
+                            store::store(
+                                self.store,
+                                trussed::types::Location::Internal,
+                                &PathBuf::from(FILENAME_P256_CERT),
+                                command.data()
+                            ).map_err(|_| Status::NotEnoughMemory)?;
+                            Ok(())
+                        }
+                    },
+
+                    SAVE_ED255_ATTESTATION_CERT => {
+                        let secret_path = PathBuf::from(FILENAME_ED255_SECRET);
+                        if !secret_path.exists(&self.store.ifs()) {
+                            Err(Status::IncorrectDataParameter)
+                        } else if command.data().len() < 100 {
+                            // Assuming certs will always be >100 bytes
+                            Err(Status::IncorrectDataParameter)
+                        } else {
+                            info!("saving ED25519 CERT, {} bytes", command.data().len());
+                            store::store(
+                                self.store,
+                                trussed::types::Location::Internal,
+                                &PathBuf::from(FILENAME_ED255_CERT),
+                                command.data()
+                            ).map_err(|_| Status::NotEnoughMemory)?;
+                            Ok(())
+                        }
+                    },
+
+                    #[cfg(feature = "test-attestation")]
+                    TEST_ATTESTATION => {
+                        // This is only exposed for development and testing.
+
+                        use trussed::{
+                            types::Mechanism,
+                            types::SignatureSerialization,
+                            types::ObjectHandle
+                        };
+
+
+                        let p1 = command.p1;
+                        let mut challenge = [0u8; 32];
+                        challenge.copy_from_slice(
+                            &syscall!(self.trussed.random_bytes(32)).bytes.as_slice()
+                        );
+
+                        match p1 {
+                            _x if p1 == TestAttestationP1::P256Sign as u8 => {
+                                let sig: Bytes<MAX_SIGNATURE_LENGTH> = syscall!(self.trussed.sign(
+                                    Mechanism::P256,
+                                    ObjectHandle{object_id: 1.into()},
+                                    &challenge,
+                                    SignatureSerialization::Asn1Der
+                                )).signature;
+
+                                // let sig = Bytes::try_from_slice(&sig);
+
+                                reply.extend_from_slice(&challenge).unwrap();
+                                reply.extend_from_slice(&sig).unwrap();
+                                Ok(())
+                            }
+                            _x if p1 == TestAttestationP1::P256Cert as u8 => {
+                                store::read(self.store,
+                                    trussed::types::Location::Internal,
+                                    &PathBuf::from(FILENAME_P256_CERT),
+                                ).map_err(|_| Status::NotFound)
+                            }
+                            _x if p1 == TestAttestationP1::Ed255Sign as u8 => {
+
+                                let sig: Bytes<MAX_SIGNATURE_LENGTH> = syscall!(self.trussed.sign(
+                                    Mechanism::Ed255,
+                                    ObjectHandle{object_id: 2.into()},
+                                    &challenge,
+                                    SignatureSerialization::Asn1Der
+                                )).signature;
+
+                                // let sig = Bytes::try_from_slice(&sig);
+
+                                reply.extend_from_slice(&challenge).unwrap();
+                                reply.extend_from_slice(&sig).unwrap();
+                                Ok(())
+                            }
+                            _x if p1 == TestAttestationP1::Ed255Cert as u8 => {
+                                store::read(self.store,
+                                    trussed::types::Location::Internal,
+                                    &PathBuf::from(FILENAME_ED255_CERT),
+                                ).map_err(|_| Status::NotFound)
+                            }
+                            _ => Err(Status::FunctionNotSupported)
+
+                        }
+
+                    }
+
+                    GET_UUID_INS => {
+                        // Get UUID
+                        reply.extend_from_slice(&hal::uuid()).unwrap();
+                        Ok(())
+                    },
+                    0x51 => {
+                        // Boot to bootrom via flash 0 page erase
+                        use hal::traits::flash::WriteErase;
+                        let flash = unsafe { hal::peripherals::flash::Flash::steal() }.enabled(
+                            &mut unsafe { hal::peripherals::syscon::Syscon::steal()}
+                        );
+                        hal::drivers::flash::FlashGordon::new(flash).erase_page(0).ok();
+                        hal::raw::SCB::sys_reset()
+                    },
+
+                    _ => {
+                        Err(Status::FunctionNotSupported)
+                    }
+                }
+            }
+            _ => Err(Status::FunctionNotSupported),
+        }
+    }
+
+    fn select(&mut self, command: &Command, _reply: &mut response::Data) -> ResponseResult {
+
+        if command.data().starts_with(&TESTER_FILENAME_ID) {
+            info!("select filename");
+            self.selected_buffer = SelectedBuffer::Filename;
+            Ok(())
+        } else if command.data().starts_with(&TESTER_FILE_ID) {
+            info!("select file");
+            self.selected_buffer = SelectedBuffer::File;
+            Ok(())
+        } else {
+            info!("unknown ID: {:?}", &command.data());
+            Err(Status::NotFound)
+        }
+
+    }
+
+}
+
+impl<S, FS, T> apdu_dispatch::app::Aid for Provisioner<S, FS, T>
+where S: Store,
+      FS: 'static + LfsStorage,
+      T: TrussedClient
+{
+
+    fn aid(&self) -> &'static [u8] {
+        &SOLO_PROVISIONER_AID
+    }
+
+    fn right_truncated_length(&self) -> usize {
+        9
+    }
+}
+
+
+impl<S, FS, T> apdu_dispatch::app::App<command::Size, response::Size> for Provisioner<S, FS, T>
+where S: Store,
+      FS: 'static + LfsStorage,
+      T: TrussedClient,
+{
+    fn select(&mut self, _apdu: &Command, reply: &mut response::Data) -> apdu_dispatch::app::Result {
+        self.buffer_file_contents.clear();
+        self.buffer_filename.clear();
+        // For manufacture speed, return uuid on select
+        reply.extend_from_slice(&hal::uuid()).unwrap();
+        Ok(())
+    }
+
+    fn deselect(&mut self) -> () {
+    }
+
+    fn call(&mut self, _interface_type: apdu_dispatch::app::Interface, apdu: &Command, reply: &mut response::Data) -> apdu_dispatch::app::Result {
+        self.handle(&apdu, reply)
+    }
+}

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -22,8 +22,7 @@ heapless = "0.6"
 interchange = "0.2.0"
 nb = "1"
 rtt-target = { version = "0.3", optional = true, features = ["cortex-m"] }
-# trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main", features = ["clients-5"] }
-trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main", features = ["clients-4"] }
+trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main" }
 usb-device = "0.2.3"
 # usbd-hid = { version = "0.4.5", optional = true }
 usbd-serial = "0.1.0"
@@ -34,22 +33,22 @@ board = { path = "board" }
 # components
 apdu-dispatch = { git = "https://github.com/solokeys/apdu-dispatch", branch = "main" }
 dispatch-fido = {path = "../../components/dispatch-fido"}
-ndef-app = {path = "../../components/ndef-app"}
-management-app = {path = "../../components/management-app"}
+ndef-app = { path = "../../components/ndef-app", optional = true }
+management-app = { path = "../../components/management-app", optional = true }
 # NB: when using this app, need to raise trussed/clients-5
 provisioner-app = { path = "../../components/provisioner-app", optional = true }
 c-stubs = { path = "../../components/c-stubs" }
 ctap-types = { path = "../../components/ctap-types" }
-fido-authenticator = { path = "../../components/fido-authenticator" }
+fido-authenticator = { path = "../../components/fido-authenticator", optional = true }
 fm11nc08 = {path = "../../components/fm11nc08"}
 ctaphid-dispatch = {path = "../../components/ctaphid-dispatch"}
 nfc-device = {path = "../../components/nfc-device"}
-piv-authenticator = { path = "../../components/piv-authenticator", features = ["apdu-dispatch"] }
+piv-authenticator = { path = "../../components/piv-authenticator", features = ["apdu-dispatch"], optional = true }
 usbd-ccid = { path = "../../components/usbd-ccid" }
 usbd-ctaphid = { path = "../../components/usbd-ctaphid" }
 
 # TODO release oath-authenticator
-oath-authenticator = { git = "https://github.com/trussed-dev/oath-authenticator", branch = "main", features = ["apdu-dispatch"] }
+oath-authenticator = { git = "https://github.com/trussed-dev/oath-authenticator", branch = "main", features = ["apdu-dispatch"], optional = true }
 
 # panic
 panic-halt = "0.2.0"
@@ -59,9 +58,10 @@ panic-halt = "0.2.0"
 littlefs2 = "0.2.1"
 
 [features]
-default = []
+default = ["fido-authenticator", "management-app", "ndef-app", "oath-authenticator", "piv-authenticator"]
 
-develop = ["no-encrypted-storage", "no-buttons", "no-reset-time-window"]
+develop = ["no-encrypted-storage", "no-buttons", "no-reset-time-window", "trussed/clients-4"]
+develop-provisioner = ["no-encrypted-storage", "no-buttons", "no-reset-time-window", "provisioner-app", "trussed/clients-5"]
 
 # Do not use encryption for the filesystem
 no-encrypted-storage = []

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -22,6 +22,7 @@ heapless = "0.6"
 interchange = "0.2.0"
 nb = "1"
 rtt-target = { version = "0.3", optional = true, features = ["cortex-m"] }
+# trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main", features = ["clients-5"] }
 trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main", features = ["clients-4"] }
 usb-device = "0.2.3"
 # usbd-hid = { version = "0.4.5", optional = true }
@@ -35,6 +36,8 @@ apdu-dispatch = { git = "https://github.com/solokeys/apdu-dispatch", branch = "m
 dispatch-fido = {path = "../../components/dispatch-fido"}
 ndef-app = {path = "../../components/ndef-app"}
 management-app = {path = "../../components/management-app"}
+# NB: when using this app, need to raise trussed/clients-5
+provisioner-app = { path = "../../components/provisioner-app", optional = true }
 c-stubs = { path = "../../components/c-stubs" }
 ctap-types = { path = "../../components/ctap-types" }
 fido-authenticator = { path = "../../components/fido-authenticator" }

--- a/runners/lpc55/Makefile
+++ b/runners/lpc55/Makefile
@@ -1,10 +1,15 @@
-FEATURES := board-lpcxpresso55,develop
+BOARD := board-lpcxpresso55
+DEVELOP := --features $(BOARD),develop
+PROVISIONER := --features $(BOARD),develop-provisioner
 
 build-dev:
-	cargo build --release --features $(FEATURES)
+	cargo build --release $(DEVELOP)
 
 run-dev:
-	cargo run --release --features $(FEATURES)
+	cargo run --release $(DEVELOP)
+
+run-pro:
+	cargo run --release $(PROVISIONER)
 
 bacon:
 	bacon

--- a/runners/lpc55/bacon.toml
+++ b/runners/lpc55/bacon.toml
@@ -9,6 +9,10 @@ default_job = "check-dev"
 command = ["cargo", "check", "--color", "always", "--features", "board-lpcxpresso55,develop"]
 need_stdout = false
 
+[jobs.build-dev]
+command = ["cargo", "build", "--color", "always", "--features", "board-lpcxpresso55,develop"]
+need_stdout = false
+
 [jobs.check]
 command = ["cargo", "check", "--color", "always", "--features"]
 need_stdout = false

--- a/runners/lpc55/src/lib.rs
+++ b/runners/lpc55/src/lib.rs
@@ -487,7 +487,17 @@ pub fn init_board(
     delay_timer.cancel().ok();
     info!("init took {} ms",perf_timer.elapsed().0/1000);
 
-    let apps = types::Apps::new(&mut trussed);
+    let apps = types::Apps::new(
+        &mut trussed,
+        #[cfg(feature = "provisioner-app")]
+        {
+            types::ProvisionerNonPortable {
+                store,
+                stolen_filesystem: unsafe { INTERNAL_STORAGE.as_mut().unwrap() },
+                nfc_powered: is_passive_mode,
+            }
+        }
+    );
 
     (
         apdu_dispatch,

--- a/runners/lpc55/src/types.rs
+++ b/runners/lpc55/src/types.rs
@@ -93,10 +93,15 @@ pub type ExternalInterrupt = hal::Pint<hal::typestates::init_state::Enabled>;
 pub type ApduDispatch = apdu_dispatch::dispatch::ApduDispatch;
 pub type CtaphidDispach = ctaphid_dispatch::dispatch::Dispatch;
 
+#[cfg(feature = "piv-authenticator")]
 pub type PivApp = piv_authenticator::Authenticator<TrussedClient>;
+#[cfg(feature = "oath-authenticator")]
 pub type OathApp = oath_authenticator::Authenticator<TrussedClient>;
+#[cfg(feature = "fido-authenticator")]
 pub type FidoApp = dispatch_fido::Fido<fido_authenticator::NonSilentAuthenticator, TrussedClient>;
+#[cfg(feature = "management-app")]
 pub type ManagementApp = management_app::App<TrussedClient>;
+#[cfg(feature = "ndef-app")]
 pub type NdefApp = ndef_app::App<'static>;
 #[cfg(feature = "provisioner-app")]
 pub type ProvisionerApp = provisioner_app::Provisioner<Store, FlashStorage, TrussedClient>;
@@ -137,6 +142,7 @@ pub trait TrussedApp: Sized {
     }
 }
 
+#[cfg(feature = "oath-authenticator")]
 impl TrussedApp for OathApp {
     const CLIENT_ID: &'static [u8] = b"oath\0";
 
@@ -146,6 +152,7 @@ impl TrussedApp for OathApp {
     }
 }
 
+#[cfg(feature = "piv-authenticator")]
 impl TrussedApp for PivApp {
     const CLIENT_ID: &'static [u8] = b"piv\0";
 
@@ -155,6 +162,7 @@ impl TrussedApp for PivApp {
     }
 }
 
+#[cfg(feature = "management-app")]
 impl TrussedApp for ManagementApp {
     const CLIENT_ID: &'static [u8] = b"mgmt\0";
 
@@ -165,6 +173,7 @@ impl TrussedApp for ManagementApp {
     }
 }
 
+#[cfg(feature = "fido-authenticator")]
 impl TrussedApp for FidoApp {
     const CLIENT_ID: &'static [u8] = b"fido\0";
 
@@ -197,10 +206,15 @@ impl TrussedApp for ProvisionerApp {
 }
 
 pub struct Apps {
+    #[cfg(feature = "management-app")]
     pub mgmt: ManagementApp,
+    #[cfg(feature = "fido-authenticator")]
     pub fido: FidoApp,
+    #[cfg(feature = "oath-authenticator")]
     pub oath: OathApp,
+    #[cfg(feature = "ndef-app")]
     pub ndef: NdefApp,
+    #[cfg(feature = "piv-authenticator")]
     pub piv: PivApp,
     #[cfg(feature = "provisioner-app")]
     pub provisioner: ProvisionerApp,
@@ -212,19 +226,29 @@ impl Apps {
         #[cfg(feature = "provisioner-app")]
         provisioner: ProvisionerNonPortable
     ) -> Self {
+        #[cfg(feature = "management-app")]
         let mgmt = ManagementApp::with(trussed, ());
+        #[cfg(feature = "fido-authenticator")]
         let fido = FidoApp::with(trussed, ());
+        #[cfg(feature = "oath-authenticator")]
         let oath = OathApp::with(trussed, ());
+        #[cfg(feature = "piv-authenticator")]
         let piv = PivApp::with(trussed, ());
+        #[cfg(feature = "ndef-app")]
         let ndef = NdefApp::new();
         #[cfg(feature = "provisioner-app")]
         let provisioner = ProvisionerApp::with(trussed, provisioner);
 
         Self {
+            #[cfg(feature = "management-app")]
             mgmt,
+            #[cfg(feature = "fido-authenticator")]
             fido,
+            #[cfg(feature = "oath-authenticator")]
             oath,
+            #[cfg(feature = "ndef-app")]
             ndef,
+            #[cfg(feature = "piv-authenticator")]
             piv,
             #[cfg(feature = "provisioner-app")]
             provisioner,
@@ -238,10 +262,15 @@ impl Apps {
             ]) -> T
     {
         f(&mut [
+            #[cfg(feature = "ndef-app")]
             &mut self.ndef,
+            #[cfg(feature = "piv-authenticator")]
             &mut self.piv,
+            #[cfg(feature = "oath-authenticator")]
             &mut self.oath,
+            #[cfg(feature = "fido-authenticator")]
             &mut self.fido,
+            #[cfg(feature = "management-app")]
             &mut self.mgmt,
             #[cfg(feature = "provisioner-app")]
             &mut self.provisioner,
@@ -253,7 +282,9 @@ impl Apps {
         F: FnOnce(&mut [&mut dyn CtaphidApp ]) -> T
     {
         f(&mut [
+            #[cfg(feature = "fido-authenticator")]
             &mut self.fido,
+            #[cfg(feature = "management-app")]
             &mut self.mgmt,
         ])
     }


### PR DESCRIPTION
Not the final stage, but a step in the right direction I think.

By our claimed definition, a "portable" Trussed app only needs
- a Trussed client
  _Explicitly modeled by injecting client in the constructor_
- to be driven by some transport/interface assumed existing in the ambient "operating system".
  _Implicitly modeled as the only interface are the dispatch methods on `Apps`, listing which interfaces to reply on for which apps_

For Solo 2, this is the NFC + USB transports, the APDU and CTAPHID dispatch interfaces.

The new trait `solo2::types::TrussedApp` encapsulates this.
- OATH, PIV fit perfectly
- NDEF is even simpler (static, no client)
- FIDO is a special case, as it has a "pure" implementation in `fido-authenticator`, with the dispatch App traits implemented in `dispatch-fido`, but then it fits in the same way
- MGMT is a special case, as it has non-portable parts.

Draft as I'm planning to add the Provisioner as a Very Nonportable app as well.