### PR TITLE
remove extra trailing zero in ndef aid

### DIFF
--- a/components/ndef-app/src/ndef.rs
+++ b/components/ndef-app/src/ndef.rs
@@ -33,9 +33,7 @@ impl<'a> App<'a> {
 
 impl<'a> app::Aid for App<'a> {
     fn aid(&self) -> &'static [u8] {
-        &[0xD2u8, 0x76, 0x00, 0x00,
-            0x85, 0x01, 0x01, 0x00,
-            ]
+        &[0xD2u8, 0x76, 0x00, 0x00, 0x85, 0x01, 0x01,]
     }
 
     fn right_truncated_length(&self) -> usize {


### PR DESCRIPTION
The correct AID is `D2760000850101`