### PR TITLE
Provision X255 Trussed agreement key

### DIFF
--- a/components/provisioner-app/src/lib.rs
+++ b/components/provisioner-app/src/lib.rs
@@ -14,6 +14,8 @@
 extern crate delog;
 generate_macros!();
 
+use core::convert::TryFrom;
+
 use trussed::types::LfsStorage;
 
 pub const FILESYSTEM_BOUNDARY: usize = 0x8_0000;
@@ -38,18 +40,50 @@ const SOLO_PROVISIONER_AID: [u8; 9] = [ 0xA0, 0x00, 0x00, 0x08, 0x47, 0x01, 0x00
 const TESTER_FILENAME_ID: [u8; 2] = [0xe1,0x01];
 const TESTER_FILE_ID: [u8; 2] = [0xe1,0x02];
 
-const WRITE_FILE_INS: u8 = 0xbf;
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Instructions {
+    WriteFile = 0xbf,
 
-const REFORMAT_FS_INS: u8 = 0xbd;
-const GET_UUID_INS: u8 = 0x62;
+    BootToBootrom = 0x51,
+    ReformatFilesystem = 0xbd,
+    GetUuid = 0x62,
 
-const GENERATE_P256_ATTESTATION: u8 = 0xbc;
-const GENERATE_ED255_ATTESTATION: u8 = 0xbb;
+    GenerateP256Key = 0xbc,
+    GenerateEd255Key = 0xbb,
+    GenerateX255Key = 0xb7,
 
-const SAVE_P256_ATTESTATION_CERT: u8 = 0xba;
-const SAVE_ED255_ATTESTATION_CERT: u8 = 0xb9;
-#[cfg(feature = "test-attestation")]
-const TEST_ATTESTATION: u8 = 0xb8;
+    SaveP256AttestationCertificate = 0xba,
+    SaveEd255AttestationCertificate = 0xb9,
+    SaveX255AttestationCertificate = 0xb6,
+    #[cfg(feature = "test-attestation")]
+    TestAttestation = 0xb8,
+}
+
+impl TryFrom<u8> for Instructions {
+    type Error = ();
+    fn try_from(ins: u8) -> core::result::Result<Self, Self::Error> {
+        use Instructions::*;
+        Ok(match ins {
+            0xbf => WriteFile,
+
+            0x51 => BootToBootrom,
+            0xbd => ReformatFilesystem,
+            0x62 => GetUuid,
+
+            0xbc => GenerateP256Key,
+            0xbb => GenerateEd255Key,
+            0xb7 => GenerateX255Key,
+
+            0xba => SaveP256AttestationCertificate,
+            0xb9 => SaveEd255AttestationCertificate,
+            0xb6 => SaveX255AttestationCertificate,
+            #[cfg(feature = "test-attestation")]
+            0xb8 => TestAttestation,
+            _ => return Err(()),
+        })
+    }
+}
 
 #[cfg(feature = "test-attestation")]
 #[derive(Copy,Clone)]
@@ -63,9 +97,11 @@ enum TestAttestationP1 {
 
 const FILENAME_P256_SECRET: &'static [u8] = b"/attn/sec/01";
 const FILENAME_ED255_SECRET: &'static [u8] = b"/attn/sec/02";
+const FILENAME_X255_SECRET: &'static [u8] = b"/attn/sec/03";
 
 const FILENAME_P256_CERT: &'static [u8] = b"/attn/x5c/01";
 const FILENAME_ED255_CERT: &'static [u8] = b"/attn/x5c/02";
+const FILENAME_X255_CERT: &'static [u8] = b"/attn/x5c/03";
 
 
 
@@ -129,221 +165,275 @@ where S: Store,
                 Ok(())
             }
             Instruction::Unknown(ins) => {
-                match ins {
-                    REFORMAT_FS_INS => {
-                        // Provide a method to reset the FS.
-                        info!("Reformatting the FS..");
-                        littlefs2::fs::Filesystem::format(self.stolen_filesystem)
-                            .map_err(|_| Status::NotEnoughMemory)?;
-                        Ok(())
-                    }
-                    WRITE_FILE_INS => {
-                        if self.buffer_file_contents.len() == 0 || self.buffer_filename.len() == 0 {
-                            Err(Status::IncorrectDataParameter)
-                        } else {
-                            // self.buffer_filename.push(0);
-                            let _filename = unsafe{ core::str::from_utf8_unchecked(self.buffer_filename.as_slice()) };
-                            info!("writing file {} {} bytes", _filename, self.buffer_file_contents.len());
-                            // logging::dump_hex(&self.buffer_file_contents, self.buffer_file_contents.len());
-
-                            let res = store::store(
-                                self.store,
-                                trussed::types::Location::Internal,
-                                &PathBuf::from(self.buffer_filename.as_slice()),
-                                &self.buffer_file_contents
-                            );
-                            self.buffer_file_contents.clear();
-                            self.buffer_filename.clear();
-                            if !res.is_ok() {
-                                info!("failed writing file!");
-                                Err(Status::NotEnoughMemory)
+                if let Ok(instruction) = Instructions::try_from(ins) {
+                    use Instructions::*;
+                    match instruction {
+                        ReformatFilesystem => {
+                            // Provide a method to reset the FS.
+                            info!("Reformatting the FS..");
+                            littlefs2::fs::Filesystem::format(self.stolen_filesystem)
+                                .map_err(|_| Status::NotEnoughMemory)?;
+                            Ok(())
+                        }
+                        WriteFile => {
+                            if self.buffer_file_contents.len() == 0 || self.buffer_filename.len() == 0 {
+                                Err(Status::IncorrectDataParameter)
                             } else {
-                                info!("wrote file");
-                                Ok(())
+                                // self.buffer_filename.push(0);
+                                let _filename = unsafe{ core::str::from_utf8_unchecked(self.buffer_filename.as_slice()) };
+                                info!("writing file {} {} bytes", _filename, self.buffer_file_contents.len());
+                                // logging::dump_hex(&self.buffer_file_contents, self.buffer_file_contents.len());
+
+                                let res = store::store(
+                                    self.store,
+                                    trussed::types::Location::Internal,
+                                    &PathBuf::from(self.buffer_filename.as_slice()),
+                                    &self.buffer_file_contents
+                                );
+                                self.buffer_file_contents.clear();
+                                self.buffer_filename.clear();
+                                if !res.is_ok() {
+                                    info!("failed writing file!");
+                                    Err(Status::NotEnoughMemory)
+                                } else {
+                                    info!("wrote file");
+                                    Ok(())
+                                }
                             }
                         }
-                    }
-                    GENERATE_P256_ATTESTATION => {
-                        info!("GENERATE_P256_ATTESTATION");
-                        let mut seed = [0u8; 32];
-                        seed.copy_from_slice(
-                            &syscall!(self.trussed.random_bytes(32)).bytes.as_slice()
-                        );
+                        GenerateP256Key => {
+                            info!("GenerateP256Key");
+                            let mut seed = [0u8; 32];
+                            seed.copy_from_slice(
+                                &syscall!(self.trussed.random_bytes(32)).bytes.as_slice()
+                            );
 
-                        let serialized_key = Key {
-                            flags: Flags::LOCAL | Flags::SENSITIVE,
-                            kind: KeyKind::P256,
-                            material: Bytes::try_from_slice(&seed).unwrap(),
-                        };
+                            let serialized_key = Key {
+                                flags: Flags::LOCAL | Flags::SENSITIVE,
+                                kind: KeyKind::P256,
+                                material: Bytes::try_from_slice(&seed).unwrap(),
+                            };
 
-                        let serialized_bytes = serialized_key.serialize();
+                            let serialized_bytes = serialized_key.serialize();
 
-                        store::store(
-                            self.store,
-                            trussed::types::Location::Internal,
-                            &PathBuf::from(FILENAME_P256_SECRET),
-                            &serialized_bytes
-                        ).map_err(|_| Status::NotEnoughMemory)?;
-                        info!("stored to {}", core::str::from_utf8(FILENAME_P256_SECRET).unwrap());
-
-                        let keypair = nisty::Keypair::generate_patiently(&seed);
-
-                        reply.extend_from_slice(keypair.public.as_bytes()).unwrap();
-                        Ok(())
-                    }
-                    GENERATE_ED255_ATTESTATION => {
-
-                        info!("GENERATE_ED255_ATTESTATION");
-                        let mut seed = [0u8; 32];
-                        seed.copy_from_slice(
-                            &syscall!(self.trussed.random_bytes(32)).bytes.as_slice()
-                        );
-
-                        let serialized_key = Key {
-                            flags: Flags::LOCAL | Flags::SENSITIVE,
-                            kind: KeyKind::Ed255,
-                            material: Bytes::try_from_slice(&seed).unwrap(),
-                        };
-
-                        // let serialized_key = Key::try_deserialize(&seed[..])
-                            // .map_err(|_| Status::WrongLength)?;
-
-                        let serialized_bytes = serialized_key.serialize();
-
-                        store::store(
-                            self.store,
-                            trussed::types::Location::Internal,
-                            &PathBuf::from(FILENAME_ED255_SECRET),
-                            &serialized_bytes
-                        ).map_err(|_| Status::NotEnoughMemory)?;
-
-                        let keypair = salty::Keypair::from(&seed);
-
-                        reply.extend_from_slice(keypair.public.as_bytes()).unwrap();
-                        Ok(())
-                    },
-
-                    SAVE_P256_ATTESTATION_CERT => {
-                        let secret_path = PathBuf::from(FILENAME_P256_SECRET);
-                        if !secret_path.exists(&self.store.ifs()) {
-                            Err(Status::IncorrectDataParameter)
-                        } else if command.data().len() < 100 {
-                            // Assuming certs will always be >100 bytes
-                            Err(Status::IncorrectDataParameter)
-                        } else {
-                            info!("saving P256 CERT, {} bytes", command.data().len());
                             store::store(
                                 self.store,
                                 trussed::types::Location::Internal,
-                                &PathBuf::from(FILENAME_P256_CERT),
-                                command.data()
+                                &PathBuf::from(FILENAME_P256_SECRET),
+                                &serialized_bytes
                             ).map_err(|_| Status::NotEnoughMemory)?;
+                            info!("stored to {}", core::str::from_utf8(FILENAME_P256_SECRET).unwrap());
+
+                            let keypair = nisty::Keypair::generate_patiently(&seed);
+
+                            reply.extend_from_slice(keypair.public.as_bytes()).unwrap();
                             Ok(())
                         }
-                    },
+                        GenerateEd255Key => {
 
-                    SAVE_ED255_ATTESTATION_CERT => {
-                        let secret_path = PathBuf::from(FILENAME_ED255_SECRET);
-                        if !secret_path.exists(&self.store.ifs()) {
-                            Err(Status::IncorrectDataParameter)
-                        } else if command.data().len() < 100 {
-                            // Assuming certs will always be >100 bytes
-                            Err(Status::IncorrectDataParameter)
-                        } else {
-                            info!("saving ED25519 CERT, {} bytes", command.data().len());
+                            info!("GenerateEd255Key");
+                            let mut seed = [0u8; 32];
+                            seed.copy_from_slice(
+                                &syscall!(self.trussed.random_bytes(32)).bytes.as_slice()
+                            );
+
+                            let serialized_key = Key {
+                                flags: Flags::LOCAL | Flags::SENSITIVE,
+                                kind: KeyKind::Ed255,
+                                material: Bytes::try_from_slice(&seed).unwrap(),
+                            };
+
+                            // let serialized_key = Key::try_deserialize(&seed[..])
+                                // .map_err(|_| Status::WrongLength)?;
+
+                            let serialized_bytes = serialized_key.serialize();
+
                             store::store(
                                 self.store,
                                 trussed::types::Location::Internal,
-                                &PathBuf::from(FILENAME_ED255_CERT),
-                                command.data()
+                                &PathBuf::from(FILENAME_ED255_SECRET),
+                                &serialized_bytes
                             ).map_err(|_| Status::NotEnoughMemory)?;
+
+                            let keypair = salty::Keypair::from(&seed);
+
+                            reply.extend_from_slice(keypair.public.as_bytes()).unwrap();
                             Ok(())
-                        }
-                    },
+                        },
 
-                    #[cfg(feature = "test-attestation")]
-                    TEST_ATTESTATION => {
-                        // This is only exposed for development and testing.
+                        GenerateX255Key => {
 
-                        use trussed::{
-                            types::Mechanism,
-                            types::SignatureSerialization,
-                            types::ObjectHandle
-                        };
+                            info!("GenerateX255Key");
+                            let mut seed = [0u8; 32];
+                            seed.copy_from_slice(
+                                &syscall!(self.trussed.random_bytes(32)).bytes.as_slice()
+                            );
 
+                            let serialized_key = Key {
+                                flags: Flags::LOCAL | Flags::SENSITIVE,
+                                kind: KeyKind::X255,
+                                material: Bytes::try_from_slice(&seed).unwrap(),
+                            };
 
-                        let p1 = command.p1;
-                        let mut challenge = [0u8; 32];
-                        challenge.copy_from_slice(
-                            &syscall!(self.trussed.random_bytes(32)).bytes.as_slice()
-                        );
+                            // let serialized_key = Key::try_deserialize(&seed[..])
+                                // .map_err(|_| Status::WrongLength)?;
 
-                        match p1 {
-                            _x if p1 == TestAttestationP1::P256Sign as u8 => {
-                                let sig: Bytes<MAX_SIGNATURE_LENGTH> = syscall!(self.trussed.sign(
-                                    Mechanism::P256,
-                                    ObjectHandle{object_id: 1.into()},
-                                    &challenge,
-                                    SignatureSerialization::Asn1Der
-                                )).signature;
+                            let serialized_bytes = serialized_key.serialize();
 
-                                // let sig = Bytes::try_from_slice(&sig);
+                            store::store(
+                                self.store,
+                                trussed::types::Location::Internal,
+                                &PathBuf::from(FILENAME_X255_SECRET),
+                                &serialized_bytes
+                            ).map_err(|_| Status::NotEnoughMemory)?;
 
-                                reply.extend_from_slice(&challenge).unwrap();
-                                reply.extend_from_slice(&sig).unwrap();
-                                Ok(())
-                            }
-                            _x if p1 == TestAttestationP1::P256Cert as u8 => {
-                                store::read(self.store,
+                            let secret_key = salty::agreement::SecretKey::from_seed(&seed);
+                            let public_key = salty::agreement::PublicKey::from(&secret_key);
+
+                            reply.extend_from_slice(&public_key.to_bytes()).unwrap();
+                            Ok(())
+                        },
+
+                        SaveP256AttestationCertificate => {
+                            let secret_path = PathBuf::from(FILENAME_P256_SECRET);
+                            if !secret_path.exists(&self.store.ifs()) {
+                                Err(Status::IncorrectDataParameter)
+                            } else if command.data().len() < 100 {
+                                // Assuming certs will always be >100 bytes
+                                Err(Status::IncorrectDataParameter)
+                            } else {
+                                info!("saving P256 CERT, {} bytes", command.data().len());
+                                store::store(
+                                    self.store,
                                     trussed::types::Location::Internal,
                                     &PathBuf::from(FILENAME_P256_CERT),
-                                ).map_err(|_| Status::NotFound)
-                            }
-                            _x if p1 == TestAttestationP1::Ed255Sign as u8 => {
-
-                                let sig: Bytes<MAX_SIGNATURE_LENGTH> = syscall!(self.trussed.sign(
-                                    Mechanism::Ed255,
-                                    ObjectHandle{object_id: 2.into()},
-                                    &challenge,
-                                    SignatureSerialization::Asn1Der
-                                )).signature;
-
-                                // let sig = Bytes::try_from_slice(&sig);
-
-                                reply.extend_from_slice(&challenge).unwrap();
-                                reply.extend_from_slice(&sig).unwrap();
+                                    command.data()
+                                ).map_err(|_| Status::NotEnoughMemory)?;
                                 Ok(())
                             }
-                            _x if p1 == TestAttestationP1::Ed255Cert as u8 => {
-                                store::read(self.store,
+                        },
+
+                        SaveEd255AttestationCertificate => {
+                            let secret_path = PathBuf::from(FILENAME_ED255_SECRET);
+                            if !secret_path.exists(&self.store.ifs()) {
+                                Err(Status::IncorrectDataParameter)
+                            } else if command.data().len() < 100 {
+                                // Assuming certs will always be >100 bytes
+                                Err(Status::IncorrectDataParameter)
+                            } else {
+                                info!("saving ED25519 CERT, {} bytes", command.data().len());
+                                store::store(
+                                    self.store,
                                     trussed::types::Location::Internal,
                                     &PathBuf::from(FILENAME_ED255_CERT),
-                                ).map_err(|_| Status::NotFound)
+                                    command.data()
+                                ).map_err(|_| Status::NotEnoughMemory)?;
+                                Ok(())
                             }
-                            _ => Err(Status::FunctionNotSupported)
+                        },
+
+                        SaveX255AttestationCertificate => {
+                            let secret_path = PathBuf::from(FILENAME_X255_SECRET);
+                            if !secret_path.exists(&self.store.ifs()) {
+                                Err(Status::IncorrectDataParameter)
+                            } else if command.data().len() < 100 {
+                                // Assuming certs will always be >100 bytes
+                                Err(Status::IncorrectDataParameter)
+                            } else {
+                                info!("saving X25519 CERT, {} bytes", command.data().len());
+                                store::store(
+                                    self.store,
+                                    trussed::types::Location::Internal,
+                                    &PathBuf::from(FILENAME_X255_CERT),
+                                    command.data()
+                                ).map_err(|_| Status::NotEnoughMemory)?;
+                                Ok(())
+                            }
+                        },
+
+                        #[cfg(feature = "test-attestation")]
+                        TestAttestation => {
+                            // This is only exposed for development and testing.
+
+                            use trussed::{
+                                types::Mechanism,
+                                types::SignatureSerialization,
+                                types::ObjectHandle
+                            };
+
+
+                            let p1 = command.p1;
+                            let mut challenge = [0u8; 32];
+                            challenge.copy_from_slice(
+                                &syscall!(self.trussed.random_bytes(32)).bytes.as_slice()
+                            );
+
+                            match p1 {
+                                _x if p1 == TestAttestationP1::P256Sign as u8 => {
+                                    let sig: Bytes<MAX_SIGNATURE_LENGTH> = syscall!(self.trussed.sign(
+                                        Mechanism::P256,
+                                        ObjectHandle{object_id: 1.into()},
+                                        &challenge,
+                                        SignatureSerialization::Asn1Der
+                                    )).signature;
+
+                                    // let sig = Bytes::try_from_slice(&sig);
+
+                                    reply.extend_from_slice(&challenge).unwrap();
+                                    reply.extend_from_slice(&sig).unwrap();
+                                    Ok(())
+                                }
+                                _x if p1 == TestAttestationP1::P256Cert as u8 => {
+                                    store::read(self.store,
+                                        trussed::types::Location::Internal,
+                                        &PathBuf::from(FILENAME_P256_CERT),
+                                    ).map_err(|_| Status::NotFound)
+                                }
+                                _x if p1 == TestAttestationP1::Ed255Sign as u8 => {
+
+                                    let sig: Bytes<MAX_SIGNATURE_LENGTH> = syscall!(self.trussed.sign(
+                                        Mechanism::Ed255,
+                                        ObjectHandle{object_id: 2.into()},
+                                        &challenge,
+                                        SignatureSerialization::Asn1Der
+                                    )).signature;
+
+                                    // let sig = Bytes::try_from_slice(&sig);
+
+                                    reply.extend_from_slice(&challenge).unwrap();
+                                    reply.extend_from_slice(&sig).unwrap();
+                                    Ok(())
+                                }
+                                _x if p1 == TestAttestationP1::Ed255Cert as u8 => {
+                                    store::read(self.store,
+                                        trussed::types::Location::Internal,
+                                        &PathBuf::from(FILENAME_ED255_CERT),
+                                    ).map_err(|_| Status::NotFound)
+                                }
+                                _ => Err(Status::FunctionNotSupported)
+
+                            }
 
                         }
 
-                    }
+                        GetUuid => {
+                            // Get UUID
+                            reply.extend_from_slice(&hal::uuid()).unwrap();
+                            Ok(())
+                        },
+                        BootToBootrom => {
+                            // Boot to bootrom via flash 0 page erase
+                            use hal::traits::flash::WriteErase;
+                            let flash = unsafe { hal::peripherals::flash::Flash::steal() }.enabled(
+                                &mut unsafe { hal::peripherals::syscon::Syscon::steal()}
+                            );
+                            hal::drivers::flash::FlashGordon::new(flash).erase_page(0).ok();
+                            hal::raw::SCB::sys_reset()
+                        },
 
-                    GET_UUID_INS => {
-                        // Get UUID
-                        reply.extend_from_slice(&hal::uuid()).unwrap();
-                        Ok(())
-                    },
-                    0x51 => {
-                        // Boot to bootrom via flash 0 page erase
-                        use hal::traits::flash::WriteErase;
-                        let flash = unsafe { hal::peripherals::flash::Flash::steal() }.enabled(
-                            &mut unsafe { hal::peripherals::syscon::Syscon::steal()}
-                        );
-                        hal::drivers::flash::FlashGordon::new(flash).erase_page(0).ok();
-                        hal::raw::SCB::sys_reset()
-                    },
-
-                    _ => {
-                        Err(Status::FunctionNotSupported)
                     }
+                } else {
+                    Err(Status::FunctionNotSupported)
                 }
             }
             _ => Err(Status::FunctionNotSupported),


### PR DESCRIPTION
To establish secure channels with a device (e.g using Noise), we should have a separate, designated, long-term, static key agreement key.