### PR TITLE
prevent subtle rust toolchain compiler error

### DIFF
--- a/runners/lpc55/.cargo/config
+++ b/runners/lpc55/.cargo/config
@@ -3,6 +3,7 @@ runner = "arm-none-eabi-gdb -q -x jlink.gdb"
 rustflags = [
   "-C", "linker=flip-link",
   "-C", "link-arg=-Tlink.x",
+  "-C", "llvm-args=--enable-machine-outliner=never",
   "-Dwarnings",
 ]
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/85351

It will be nice once this optimization becomes stable.  Saves about 5% on program space.