### PR TITLE
refactor the initialization for lpc55

### DIFF
--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # resolver = "2"
 
 [lib]
-name = "app"
+name = "runner"
 
 [[bin]]
 name = "runner"
@@ -58,13 +58,16 @@ panic-halt = "0.2.0"
 littlefs2 = "0.2.1"
 
 [features]
-default = ["admin-app", "fido-authenticator", "ndef-app", "oath-authenticator", "piv-authenticator"]
+default = ["admin-app", "fido-authenticator", "ndef-app", "oath-authenticator", "piv-authenticator", "trussed/clients-4"]
 
 develop = ["no-encrypted-storage", "no-buttons", "no-reset-time-window", "trussed/clients-4"]
 develop-provisioner = ["no-encrypted-storage", "no-buttons", "no-reset-time-window", "provisioner-app", "trussed/clients-5"]
 
 # Do not use encryption for the filesystem
 no-encrypted-storage = []
+
+# Check for undefined flash and write to determined value (for prince provisioning)
+write-undefined-flash = []
 
 # Use to auto-succeed every user presence check
 no-buttons = ["board/no-buttons"]

--- a/runners/lpc55/board/src/nfc.rs
+++ b/runners/lpc55/board/src/nfc.rs
@@ -52,7 +52,7 @@ pub fn try_setup(
     // fm: &mut NfcChip,
     timer: &mut Timer<impl hal::peripherals::ctimer::Ctimer<hal::typestates::init_state::Enabled>>,
     always_reconfig: bool,
-    ) -> Result<NfcChip, ()> {
+    ) -> Option<NfcChip> {
 
 
     let sck = NfcSckPin::take().unwrap().into_spi0_sck_pin(iocon);
@@ -85,7 +85,7 @@ pub fn try_setup(
     if current_regu_config == 0xff {
         // No nfc chip connected
         info!("No NFC chip connected");
-        return Err(());
+        return None;
     }
 
     let reconfig = always_reconfig || (current_regu_config != REGU_CONFIG) || (is_select_int_masked);
@@ -115,7 +115,7 @@ pub fn try_setup(
         }, timer);
         if r.is_err() {
             info!("Eeprom failed.  No NFC chip connected?");
-            return Err(());
+            return None;
         }
     } else {
         info!("EEPROM already initialized.");
@@ -143,6 +143,6 @@ pub fn try_setup(
     // let regu_powered = (0b11 << 4) | (0b10 << 2) | (0b11 << 0);
     // fm.write_reg(Register::ReguCfg, regu_powered);
 
-    Ok(fm)
+    Some(fm)
 }
 

--- a/runners/lpc55/jlink.gdb
+++ b/runners/lpc55/jlink.gdb
@@ -3,9 +3,6 @@
 set history save on
 set confirm off
 
-# find commit-hash using `rustc -Vv`
-set substitute-path /rustc/8d69840ab92ea7f4d323420088dd8c9775f180cd /home/nicolas/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust
-
 target extended-remote :2331
 load
 monitor reset

--- a/runners/lpc55/src/initializer.rs
+++ b/runners/lpc55/src/initializer.rs
@@ -1,0 +1,814 @@
+use crate::hal;
+use hal::prelude::*;
+use hal::traits::wg::digital::v2::InputPin;
+use hal::traits::wg::timer::Cancel;
+use hal::drivers::timer::Elapsed;
+use hal::drivers::{
+    clocks::Clocks,
+    flash::FlashGordon,
+    pins::direction,
+    pins,
+    UsbBus,
+    Pwm,
+    Timer
+};
+use hal::typestates::pin::state::Gpio;
+use hal::peripherals::{
+    ctimer,
+    ctimer::Ctimer,
+};
+use hal::peripherals::pfr::Pfr;
+use hal::typestates::init_state::Unknown;
+use usb_device::device::{UsbDeviceBuilder, UsbVidPid};
+
+use interchange::Interchange;
+use trussed::platform::UserInterface;
+
+use board::traits::buttons;
+use board::traits::buttons::Press;
+use board::traits::rgb_led::RgbLed;
+
+use crate::{types, clock_controller, build_constants};
+
+pub mod stages;
+
+pub trait State {}
+pub struct Booted;
+pub struct EnabledIo;
+
+pub enum UsbProductName {
+    /// Use custom provided string
+    Custom(&'static str),
+    /// Attempt to use string written to PFR location, using a default on failure.
+    UsePfr,
+}
+
+pub struct UsbConfig {
+    pub product_name: UsbProductName,
+    pub manufacturer_name: &'static str,
+    pub vid_pid: UsbVidPid,
+}
+
+pub struct Config {
+    /// If provided, check secure and nonsecure versions in CFPA, and update if necessary.
+    pub secure_firmware_version: Option<u32>,
+    /// Enable NFC operation.
+    pub nfc_enabled: bool,
+    /// Panic if prince has not been provisioned in CFPA.
+    pub require_prince: bool, 
+    /// If buttons are all activated for 5s, boot rom will boot.  Otherwise ignore.
+    pub boot_to_bootrom: bool,
+    /// For Usb initialization
+    pub usb_config: Option<UsbConfig>,
+}
+
+/// For initializing the LPC55 runner safely.
+pub struct Initializer {
+    is_nfc_passive: bool,
+    // hal: hal::Peripherals,
+    syscon: hal::Syscon,
+    pmc: hal::Pmc,
+    anactrl: hal::Anactrl,
+    config: Config,
+}
+
+fn get_serial_number() -> &'static str {
+    static mut SERIAL_NUMBER: heapless::String<heapless::consts::U36> = heapless::String(heapless::i::String::new());
+    use core::fmt::Write;
+    unsafe {
+        let uuid = crate::hal::uuid();
+        SERIAL_NUMBER.write_fmt(format_args!("{}", hexstr!(&uuid))).unwrap();
+        &SERIAL_NUMBER
+    }
+}
+
+// SoloKeys stores a product string in the first 64 bytes of CMPA.
+fn get_product_string(pfr: &mut Pfr<hal::typestates::init_state::Enabled>) -> &'static str {
+    let data = pfr.cmpa_customer_data();
+
+    // check the first 64 bytes of customer data for a string
+    if data[0] != 0 {
+        for i in 1 .. 64 {
+            if data[i] == 0 {
+                let str_maybe = core::str::from_utf8(&data[0 .. i]);
+                if let Ok(string) = str_maybe {
+                    return string;
+                }
+                break;
+            }
+        }
+    }
+
+    // Use a default string
+    "Solo 2 (custom)"
+}
+
+#[cfg(feature = "write-undefined-flash")]
+/// This is necessary if prince encryption is enabled for the first time
+/// after it was first provisioned.  In this case, there can be an exception
+/// reading from undefined flash.  To fix, we run a pass over all filesystem
+/// flash and set it to a defined value.
+fn initialize_fs_flash(flash_gordon: &mut FlashGordon, prince: &mut hal::Prince<hal::typestates::init_state::Enabled>) {
+    let page_count = ((631 * 1024 + 512) - build_constants::CONFIG_FILESYSTEM_BOUNDARY) / 512;
+
+    let mut page_data = [0u8; 512];
+    for page in 0 .. page_count {
+
+        // With prince turned off, this should read as encrypted bytes.
+        flash_gordon.read(build_constants::CONFIG_FILESYSTEM_BOUNDARY + page * 512, &mut page_data);
+
+        // But if it's zero, then that means the data is undefined and it doesn't bother.
+        if page_data == [0u8; 512] {
+            info_now!("resetting page {}", page);
+            // So we should write nonzero data to initialize flash.
+            // We write it as encrypted, so it is in a known state when decrypted by the filesystem layer.
+            page_data[0] = 1;
+            flash_gordon.erase_page(build_constants::CONFIG_FILESYSTEM_BOUNDARY / 512 + page).ok();
+            prince.write_encrypted(|prince| {
+                prince.enable_region_2_for(||{
+                    flash_gordon.write(build_constants::CONFIG_FILESYSTEM_BOUNDARY + page * 512, &page_data).unwrap();
+                })
+            });
+        }
+    }
+}
+
+impl Initializer {
+    pub fn new(
+        config: Config,
+        syscon: hal::Syscon,
+        pmc: hal::Pmc,
+        anactrl: hal::Anactrl,
+    ) -> Self {
+        let is_nfc_passive = false;
+        Self {
+            is_nfc_passive,
+
+            syscon,
+            pmc,
+            anactrl,
+
+            config,
+        }
+    }
+
+    fn enable_low_speed_for_passive_nfc(&mut self, mut iocon: hal::Iocon<hal::Enabled>, gpio: &mut hal::Gpio<hal::Enabled>)
+        -> (hal::Iocon<hal::Enabled>, hal::Pin<board::nfc::NfcIrqPin, Gpio<direction::Input>>)
+    {
+        let nfc_irq = board::nfc::NfcIrqPin::take().unwrap().into_gpio_pin(&mut iocon, gpio).into_input();
+        // Need to enable pullup for NFC IRQ input.
+        let iocon = iocon.release();
+        iocon.pio0_19.modify(|_,w| { w.mode().pull_up() } );
+        let iocon = hal::Iocon::from(iocon).enabled(&mut self.syscon);
+        let is_passive_mode = nfc_irq.is_low().ok().unwrap();
+
+        self.is_nfc_passive = is_passive_mode;
+
+        (iocon, nfc_irq)
+    }
+
+    fn enable_clocks(&mut self) -> Clocks {
+        let anactrl = &mut self.anactrl;
+        let pmc = &mut self.pmc;
+        let syscon = &mut self.syscon;
+
+        // Start out with slow clock if in passive mode;
+        if self.is_nfc_passive {
+            hal::ClockRequirements::default()
+                .system_frequency(4.MHz())
+                .configure(anactrl, pmc, syscon)
+                .expect("Clock configuration failed")
+        } else {
+            hal::ClockRequirements::default()
+                .system_frequency(96.MHz())
+                .configure(anactrl, pmc, syscon)
+                .expect("Clock configuration failed")
+        }
+    }
+
+    fn is_bootrom_requested<T: Ctimer<hal::Enabled>>(&mut self, three_buttons: &board::ThreeButtons, timer: &mut Timer<T>) -> bool {
+        // Boot to bootrom if buttons are all held for 5s
+        timer.start(5_000_000.microseconds());
+        while three_buttons.is_pressed(buttons::Button::A) &&
+              three_buttons.is_pressed(buttons::Button::B) &&
+              three_buttons.is_pressed(buttons::Button::Middle) {
+            // info!("3 buttons pressed..");
+            if timer.wait().is_ok() {
+                return true;
+            }
+        }
+        timer.cancel().ok();
+
+        false
+    }
+
+    fn validate_cfpa(pfr: &mut Pfr<hal::Enabled>, current_version_maybe: Option<u32>, require_prince: bool) {
+        let mut cfpa = pfr.read_latest_cfpa().unwrap();
+        if let Some(current_version) = current_version_maybe {
+            if cfpa.secure_fw_version < current_version || cfpa.ns_fw_version < current_version {
+                info!("updating cfpa from {} to {}", cfpa.secure_fw_version, current_version);
+
+                // All of these are monotonic counters.
+                cfpa.version += 1;
+                cfpa.secure_fw_version = current_version;
+                cfpa.ns_fw_version = current_version;
+                pfr.write_cfpa(&cfpa).unwrap();
+            } else {
+                info!("do not need to update cfpa version {}", cfpa.secure_fw_version);
+            }
+        }
+
+        if require_prince {
+            #[cfg(not(feature = "no-encrypted-storage"))]
+            assert!(
+                cfpa.key_provisioned(hal::peripherals::pfr::KeyType::PrinceRegion2)
+            );
+        }
+    }
+
+    fn try_enable_fm11nc08 <T: Ctimer<hal::Enabled>>(
+        &mut self, 
+        clocks: &Clocks,
+        iocon: &mut hal::Iocon<hal::Enabled>,
+        gpio: &mut hal::Gpio<hal::Enabled>,
+        nfc_irq: hal::Pin<board::nfc::NfcIrqPin, Gpio<direction::Input>>,
+        delay_timer: &mut Timer<T>,
+
+        flexcomm0: hal::peripherals::flexcomm::Flexcomm0<Unknown>,
+        inputmux: hal::peripherals::inputmux::InputMux<Unknown>,
+        pint: hal::peripherals::pint::Pint<Unknown>,
+    ) -> Option<board::nfc::NfcChip> {
+        let token = clocks.support_flexcomm_token().unwrap();
+        let syscon = &mut self.syscon;
+        let spi = flexcomm0.enabled_as_spi(syscon, &token);
+
+        // TODO save these so they can be released later
+        let mut mux = inputmux.enabled(syscon);
+        let mut pint = pint.enabled(syscon);
+        pint.enable_interrupt(&mut mux, &nfc_irq, hal::peripherals::pint::Slot::Slot0, hal::peripherals::pint::Mode::ActiveLow);
+        mux.disabled(syscon);
+
+        let force_nfc_reconfig = cfg!(feature = "reconfigure-nfc");
+
+        board::nfc::try_setup(
+            spi,
+            gpio,
+            iocon,
+            nfc_irq,
+            delay_timer,
+            force_nfc_reconfig,
+        )
+
+    }
+
+    pub fn initialize_clocks(&mut self,
+        iocon: hal::Iocon<Unknown>,
+        gpio: hal::Gpio<Unknown>,
+    ) -> stages::Clock {
+
+        let syscon = &mut self.syscon;
+
+        let mut iocon = iocon.enabled(syscon);
+        let mut gpio = gpio.enabled(syscon);
+
+        let nfc_irq = if self.config.nfc_enabled {
+            let (new_iocon, nfc_irq) = self.enable_low_speed_for_passive_nfc(iocon, &mut gpio);
+            iocon = new_iocon;
+            Some(nfc_irq)
+        } else {
+            None
+        };
+
+        let clocks = self.enable_clocks();
+
+        stages::Clock {
+            nfc_irq,
+            clocks,
+            iocon,
+            gpio,
+            _clock: (),
+        }
+
+    }
+
+    pub fn initialize_basic(&mut self,
+        mut clock_stage: stages::Clock,
+        adc: hal::Adc<Unknown>,
+        _dma: hal::Dma<Unknown>,
+        delay_timer: ctimer::Ctimer0,
+        ctimer1: ctimer::Ctimer1,
+        ctimer2: ctimer::Ctimer2,
+        _ctimer3: ctimer::Ctimer3,
+        perf_timer: ctimer::Ctimer4,
+        pfr: Pfr<Unknown>,
+    ) -> stages::Basic {
+
+        let clocks = clock_stage.clocks;
+
+        let mut three_buttons: Option<board::ThreeButtons> = None;
+
+        let pmc = &mut self.pmc;
+        let syscon = &mut self.syscon;
+
+        // Start out with slow clock if in passive mode;
+        #[allow(unused_mut)]
+        let mut adc = Some(if self.is_nfc_passive {
+            // important to start Adc early in passive mode
+            hal::Adc::from(adc)
+                .configure(board::clock_controller::DynamicClockController::adc_configuration())
+                .enabled(pmc, syscon)
+        } else {
+            hal::Adc::from(adc)
+                .enabled(pmc, syscon)
+        });
+
+        let mut delay_timer = Timer::new(delay_timer.enabled(syscon, clocks.support_1mhz_fro_token().unwrap()));
+        let mut perf_timer = Timer::new(perf_timer.enabled(syscon, clocks.support_1mhz_fro_token().unwrap()));
+        perf_timer.start(60_000_000.microseconds());
+
+        let iocon = &mut clock_stage.iocon;
+        let gpio = &mut clock_stage.gpio;
+
+        #[cfg(feature = "board-lpcxpresso55")]
+        let mut rgb = board::RgbLed::new(
+            Pwm::new(ctimer2.enabled(syscon, clocks.support_1mhz_fro_token().unwrap())),
+            iocon,
+        );
+
+        #[cfg(feature = "board-solo2")]
+        let mut rgb = board::RgbLed::new(
+            Pwm::new(_ctimer3.enabled(syscon, clocks.support_1mhz_fro_token().unwrap())),
+            iocon,
+        );
+
+        if !self.is_nfc_passive {
+            #[cfg(feature = "board-lpcxpresso55")]
+            let new_three_buttons = board::ThreeButtons::new(
+                Timer::new(ctimer1.enabled(syscon, clocks.support_1mhz_fro_token().unwrap())),
+                gpio,
+                iocon,
+            );
+
+            #[cfg(feature = "board-solo2")]
+            let new_three_buttons = {
+                // TODO this should get saved somewhere to be released later.
+                let mut dma = hal::Dma::from(_dma).enabled(syscon);
+
+                board::ThreeButtons::new (
+                    adc.take().unwrap(),
+                    ctimer1.enabled(syscon, clocks.support_1mhz_fro_token().unwrap()),
+                    ctimer2.enabled(syscon, clocks.support_1mhz_fro_token().unwrap()),
+                    &mut dma,
+                    clocks.support_touch_token().unwrap(),
+                    gpio,
+                    iocon,
+                )
+            };
+
+            if self.config.boot_to_bootrom {
+                info!("bootrom request start {}", perf_timer.elapsed().0/1000);
+                if self.is_bootrom_requested(&new_three_buttons, &mut delay_timer) {
+                    // Give a small red blink show success
+                    rgb.red(200); rgb.green(0); rgb.blue(0);
+                    delay_timer.start(100_000.microseconds()); nb::block!(delay_timer.wait()).ok();
+
+                    hal::boot_to_bootrom()
+                }
+            }
+            three_buttons = Some(new_three_buttons);
+        }
+
+        let mut pfr = pfr.enabled(&clocks).unwrap();
+        Self::validate_cfpa(&mut pfr, self.config.secure_firmware_version, self.config.require_prince);
+
+        stages::Basic {
+            clock_stage,
+
+            delay_timer,
+            perf_timer,
+            pfr,
+
+            adc,
+            three_buttons,
+            rgb: Some(rgb),
+        }
+    }
+
+    pub fn initialize_nfc(&mut self,
+        mut basic_stage: stages::Basic,
+        flexcomm0: hal::peripherals::flexcomm::Flexcomm0<Unknown>,
+        mux: hal::peripherals::inputmux::InputMux<Unknown>,
+        pint: hal::peripherals::pint::Pint<Unknown>,
+    ) -> stages::Nfc {
+
+        let nfc_chip = if self.config.nfc_enabled {
+            self.try_enable_fm11nc08(
+                &basic_stage.clock_stage.clocks,
+                &mut basic_stage.clock_stage.iocon,
+                &mut basic_stage.clock_stage.gpio,
+                basic_stage.clock_stage.nfc_irq.take().unwrap(),
+                &mut basic_stage.delay_timer,
+                flexcomm0,
+                mux,
+                pint,
+            )
+        } else {
+            None
+        };
+    
+        let mut iso14443: Option<nfc_device::Iso14443<board::nfc::NfcChip>> = None;
+
+        let (contactless_requester, contactless_responder) = apdu_dispatch::interchanges::Contactless::claim()
+            .expect("could not setup iso14443 ApduInterchange");
+
+        if nfc_chip.is_some() {
+            iso14443 = Some(nfc_device::Iso14443::new(
+                nfc_chip.unwrap(), contactless_requester)
+            )
+        } else if self.is_nfc_passive {
+            info!("Shouldn't get passive signal when there's no chip!");
+        }
+
+        if let Some(iso14443) = &mut iso14443 { iso14443.poll(); }
+        if self.is_nfc_passive {
+            // Give a small delay to charge up capacitors
+            basic_stage.delay_timer.start(5_000.microseconds()); nb::block!(basic_stage.delay_timer.wait()).ok();
+        }
+        if let Some(iso14443) = &mut iso14443 { iso14443.poll(); }
+
+        stages::Nfc {
+            basic_stage,
+            iso14443,
+            contactless_responder: Some(contactless_responder),
+        }
+
+    }
+
+    pub fn initialize_usb(
+        &mut self,
+        mut nfc_stage: stages::Nfc,
+        _usbhs: hal::peripherals::usbhs::Usbhs<Unknown>,
+        _usbfs: hal::peripherals::usbfs::Usbfs<Unknown>,
+    ) -> stages::Usb {
+        let syscon = &mut self.syscon;
+        let pmc = &mut self.pmc;
+        let anactrl = &mut self.anactrl;
+
+        let (contact_requester, contact_responder) = apdu_dispatch::interchanges::Contact::claim()
+            .expect("could not setup ccid ApduInterchange");
+
+        let (ctaphid_requester, ctaphid_responder) = ctaphid_dispatch::types::HidInterchange::claim()
+            .expect("could not setup HidInterchange");
+
+        info!("usb class start {} ms", nfc_stage.perf_timer.elapsed().0/1000);
+
+        let mut usb_classes: Option<types::UsbClasses> = None;
+
+        if !self.is_nfc_passive {
+            let iocon = &mut nfc_stage.iocon;
+
+            let usb_config = self.config.usb_config.take().unwrap();
+
+            let usb0_vbus_pin = pins::Pio0_22::take().unwrap()
+                .into_usb0_vbus_pin(iocon);
+
+            #[cfg(not(feature = "usbfs-peripheral"))]
+            let mut usbd = _usbhs.enabled_as_device(
+                anactrl,
+                pmc,
+                syscon,
+                &mut nfc_stage.basic_stage.delay_timer,
+                nfc_stage.basic_stage.clock_stage.clocks.support_usbhs_token().unwrap(),
+            );
+            #[cfg(feature = "usbfs-peripheral")]
+            let usbd = _usbfs.enabled_as_device(
+                anactrl,
+                pmc,
+                syscon,
+                clocks.support_usbfs_token().unwrap(),
+            );
+            #[cfg(not(any(feature = "highspeed", feature = "usbfs-peripheral")))]
+            usbd.disable_high_speed();
+            let _: types::EnabledUsbPeripheral = usbd;
+
+            // ugh, what's the nice way?
+            static mut USB_BUS: Option<usb_device::bus::UsbBusAllocator<UsbBus<types::EnabledUsbPeripheral>>> = None;
+            unsafe { USB_BUS.replace(hal::drivers::UsbBus::new(usbd, usb0_vbus_pin)); }
+            let usb_bus = unsafe { USB_BUS.as_ref().unwrap() };
+
+            // our USB classes (must be allocated in order that they're passed in `.poll(...)` later!)
+            let ccid = usbd_ccid::Ccid::new(usb_bus, contact_requester);
+            let current_time = nfc_stage.perf_timer.elapsed().0/1000;
+            let ctaphid = usbd_ctaphid::CtapHid::new(usb_bus, ctaphid_requester, current_time)
+                .implements_ctap1()
+                .implements_ctap2()
+                .implements_wink();
+
+            let serial = usbd_serial::SerialPort::new(usb_bus);
+
+            // Only 16 bits, so take the upper bits of our semver
+            let device_release =
+                ((build_constants::CARGO_PKG_VERSION_MAJOR as u16) << 8) |
+                (build_constants::CARGO_PKG_VERSION_MINOR as u16);
+
+            // our composite USB device
+            let product_string = match usb_config.product_name {
+                UsbProductName::Custom(name) => name,
+                UsbProductName::UsePfr => get_product_string(&mut nfc_stage.pfr),
+            };
+            let serial_number = get_serial_number();
+
+            let usbd = UsbDeviceBuilder::new(usb_bus, usb_config.vid_pid)
+                .manufacturer(usb_config.manufacturer_name)
+                .product(product_string)
+                .serial_number(serial_number)
+                .device_release(device_release)
+                .max_packet_size_0(64)
+                .composite_with_iads()
+                .build();
+
+            usb_classes = Some(types::UsbClasses::new(usbd, ccid, ctaphid, /*keyboard,*/ serial));
+
+        }
+
+        stages::Usb { 
+            nfc_stage,
+            usb_classes,
+            contact_responder: Some(contact_responder),
+            ctaphid_responder: Some(ctaphid_responder),
+        }
+    }
+
+    pub fn initialize_interfaces(&mut self, mut usb_stage: stages::Usb) -> stages::Interfaces {
+
+        let apdu_dispatch = types::ApduDispatch::new(
+            usb_stage.contact_responder.take().unwrap(),
+            usb_stage.contactless_responder.take().unwrap(),
+        );
+        let ctaphid_dispatch = types::CtaphidDispatch::new(
+            usb_stage.ctaphid_responder.take().unwrap()
+        );
+
+        // Cancel any possible outstanding use in delay timing
+        usb_stage.delay_timer.cancel().ok();
+
+        stages::Interfaces {
+            usb_stage,
+            apdu_dispatch,
+            ctaphid_dispatch,
+        }
+    }
+
+    pub fn initialize_flash(
+        &mut self,
+        interfaces_stage: stages::Interfaces,
+        rng: hal::peripherals::rng::Rng<Unknown>,
+        prince: hal::peripherals::prince::Prince<Unknown>,
+        flash: hal::peripherals::flash::Flash<Unknown>,
+    ) -> stages::Flash {
+        let syscon = &mut self.syscon;
+
+        #[allow(unused_mut)]
+        let mut rng = rng.enabled(syscon);
+
+        let prince = prince.enabled(&mut rng);
+        prince.disable_all_region_2();
+
+        let flash_gordon = Some(FlashGordon::new(flash.enabled(syscon)));
+
+        stages::Flash {
+            interfaces_stage,
+            flash_gordon,
+            prince: Some(prince),
+            rng: Some(rng),
+        }
+    }
+
+    pub fn initialize_filesystem(&mut self, mut flash_stage: stages::Flash) -> stages::Filesystem {
+        use littlefs2::fs::{Allocation, Filesystem};
+        use types::{ExternalStorage, VolatileStorage};
+
+        let syscon = &mut self.syscon;
+        let pmc = &mut self.pmc;
+
+        #[allow(unused_mut)]
+        let mut flash_gordon = flash_stage.flash_gordon.take().unwrap();
+
+        #[cfg(not(feature = "no-encrypted-storage"))]
+        let filesystem = {
+            #[allow(unused_mut)]
+            let mut prince = flash_stage.prince.take().unwrap();
+
+            #[cfg(feature = "write-undefined-flash")]
+            initialize_fs_flash(&mut flash_gordon, &mut prince);
+
+            types::PrinceFilesystem::new(
+                flash_gordon,
+                prince,
+            )
+        };
+
+        #[cfg(feature = "no-encrypted-storage")]
+        let filesystem = types::PlainFilesystem::new(flash_gordon);
+
+        // temporarily increase clock for the storage mounting or else it takes a long time.
+        if self.is_nfc_passive {
+            flash_stage.clocks = unsafe { hal::ClockRequirements::default()
+                .system_frequency(48.MHz())
+                .reconfigure(flash_stage.clocks, pmc, syscon) };
+        }
+        info!("mount start {} ms", flash_stage.perf_timer.elapsed().0/1000);
+        static mut INTERNAL_STORAGE: Option<types::FlashStorage> = None;
+        unsafe { INTERNAL_STORAGE.replace(filesystem); }
+        static mut INTERNAL_FS_ALLOC: Option<Allocation<types::FlashStorage>> = None;
+        unsafe { INTERNAL_FS_ALLOC = Some(Filesystem::allocate()); }
+
+        static mut EXTERNAL_STORAGE: ExternalStorage = ExternalStorage::new();
+        static mut EXTERNAL_FS_ALLOC: Option<Allocation<ExternalStorage>> = None;
+        unsafe { EXTERNAL_FS_ALLOC = Some(Filesystem::allocate()); }
+
+        static mut VOLATILE_STORAGE: VolatileStorage = VolatileStorage::new();
+        static mut VOLATILE_FS_ALLOC: Option<Allocation<VolatileStorage>> = None;
+        unsafe { VOLATILE_FS_ALLOC = Some(Filesystem::allocate()); }
+
+        let store = types::Store::claim().unwrap();
+
+        if let Some(iso14443) = &mut flash_stage.iso14443 { iso14443.poll(); }
+
+        let result = store.mount(
+            unsafe { INTERNAL_FS_ALLOC.as_mut().unwrap() },
+            // unsafe { &mut INTERNAL_STORAGE },
+            unsafe { INTERNAL_STORAGE.as_mut().unwrap() },
+            unsafe { EXTERNAL_FS_ALLOC.as_mut().unwrap() },
+            unsafe { &mut EXTERNAL_STORAGE },
+            unsafe { VOLATILE_FS_ALLOC.as_mut().unwrap() },
+            unsafe { &mut VOLATILE_STORAGE },
+            // to trash existing data, set to true
+            false,
+        );
+
+
+        if result.is_err() || cfg!(feature = "format-filesystem") {
+            let rgb = flash_stage.rgb.as_mut().unwrap();
+            rgb.blue(200);
+            rgb.red(200);
+
+            flash_stage.delay_timer.start(300_000.microseconds());
+            nb::block!(flash_stage.delay_timer.wait()).ok();
+
+            info!("Not yet formatted!  Formatting..");
+            store.mount(
+                unsafe { INTERNAL_FS_ALLOC.as_mut().unwrap() },
+                // unsafe { &mut INTERNAL_STORAGE },
+                unsafe { INTERNAL_STORAGE.as_mut().unwrap() },
+                unsafe { EXTERNAL_FS_ALLOC.as_mut().unwrap() },
+                unsafe { &mut EXTERNAL_STORAGE },
+                unsafe { VOLATILE_FS_ALLOC.as_mut().unwrap() },
+                unsafe { &mut VOLATILE_STORAGE },
+                // to trash existing data, set to true
+                true,
+            ).unwrap();
+        }
+        info!("mount end {} ms",flash_stage.perf_timer.elapsed().0/1000);
+
+        // return to slow freq
+        if self.is_nfc_passive {
+            flash_stage.clocks = unsafe { hal::ClockRequirements::default()
+                .system_frequency(12.MHz())
+                .reconfigure(flash_stage.clocks, pmc, syscon) };
+        }
+
+        if let Some(iso14443) = &mut flash_stage.iso14443 { iso14443.poll(); }
+
+        stages::Filesystem {
+            flash_stage,
+            store,
+            internal_storage_fs: unsafe { &mut INTERNAL_STORAGE },
+        }
+    }
+
+
+
+    pub fn initialize_trussed(
+        &mut self,
+        mut filesystem_stage: stages::Filesystem,
+        rtc: hal::peripherals::rtc::Rtc<Unknown>,
+    ) -> stages::Trussed {
+        let syscon = &mut self.syscon;
+        let pmc = &mut self.pmc;
+        let clocks = filesystem_stage.clocks;
+
+        let mut rtc = rtc.enabled(syscon, clocks.enable_32k_fro(pmc));
+        rtc.reset();
+
+        let rgb = if self.is_nfc_passive {
+            None
+        } else {
+            filesystem_stage.rgb.take()
+        };
+
+        let three_buttons = filesystem_stage.three_buttons.take();
+
+        let mut solobee_interface = board::trussed::UserInterface::new(rtc, three_buttons, rgb);
+        solobee_interface.set_status(trussed::platform::ui::Status::Idle);
+
+        let rng = filesystem_stage.rng.take().unwrap();
+        let store = filesystem_stage.store;
+        let board = types::Board::new(rng, store, solobee_interface);
+        let trussed = trussed::service::Service::new(board);
+
+        stages::Trussed {
+            filesystem_stage,
+            trussed,
+        }
+    }
+
+    pub fn initialize_all(&mut self,
+        iocon: hal::Iocon<Unknown>,
+        gpio: hal::Gpio<Unknown>,
+
+        adc: hal::Adc<Unknown>,
+        dma: hal::peripherals::dma::Dma<Unknown>,
+        delay_timer: ctimer::Ctimer0,
+        ctimer1: ctimer::Ctimer1,
+        ctimer2: ctimer::Ctimer2,
+        ctimer3: ctimer::Ctimer3,
+        perf_timer: ctimer::Ctimer4,
+        pfr: Pfr<Unknown>,
+
+        flexcomm0: hal::peripherals::flexcomm::Flexcomm0<Unknown>,
+        mux: hal::peripherals::inputmux::InputMux<Unknown>,
+        pint: hal::peripherals::pint::Pint<Unknown>,
+
+        usbhs: hal::peripherals::usbhs::Usbhs<Unknown>,
+        usbfs: hal::peripherals::usbfs::Usbfs<Unknown>,
+
+        rng: hal::peripherals::rng::Rng<Unknown>,
+        prince: hal::peripherals::prince::Prince<Unknown>,
+        flash: hal::peripherals::flash::Flash<Unknown>,
+
+        rtc: hal::peripherals::rtc::Rtc<Unknown>,
+    ) -> stages::Trussed {
+        let clock_stage = self.initialize_clocks(iocon, gpio,);
+        let basic_stage = self.initialize_basic(
+            clock_stage,
+            adc,
+            dma,
+            delay_timer,
+            ctimer1,
+            ctimer2,
+            ctimer3,
+            perf_timer,
+            pfr,
+        );
+        let nfc_stage = self.initialize_nfc(basic_stage, flexcomm0, mux, pint);
+
+        let usb_stage = self.initialize_usb(nfc_stage, usbhs, usbfs);
+        let interfaces_stage = self.initialize_interfaces(usb_stage);
+        let flash_stage = self.initialize_flash(
+            interfaces_stage,
+            rng,
+            prince,
+            flash,
+        );
+        let filesystem_stage = self.initialize_filesystem(flash_stage);
+
+        let trussed_stage = self.initialize_trussed(filesystem_stage, rtc);
+
+        trussed_stage
+    }
+
+    /// Consumes the initializer -- must be done last.
+    pub fn get_dynamic_clock_control(self, basic_stage: &mut stages::Basic) 
+    -> Option<clock_controller::DynamicClockController> {
+        if self.is_nfc_passive {
+
+            let adc = basic_stage.adc.take();
+            let clocks = basic_stage.clocks;
+
+            let pmc = self.pmc;
+            let syscon = self.syscon;
+
+            let gpio = &mut basic_stage.clock_stage.gpio;
+            let iocon = &mut basic_stage.clock_stage.iocon;
+
+            let mut new_clock_controller = clock_controller::DynamicClockController::new(adc.unwrap(),
+                clocks, pmc, syscon, gpio, iocon);
+            new_clock_controller.start_high_voltage_compare();
+
+            Some(new_clock_controller)
+        } else {
+            None
+        }
+    }
+
+    /// See if LPC55 will be in NFC passive operation.  Requires first initialization stage have been done.
+    pub fn is_in_passive_operation(&self, _clock_stage: &stages::Basic) 
+    -> bool {
+        return self.is_nfc_passive;
+    }
+
+}
+
+
+

--- a/runners/lpc55/src/initializer/stages.rs
+++ b/runners/lpc55/src/initializer/stages.rs
@@ -1,0 +1,161 @@
+//! # Initialization stages for LPC55.
+//! 
+//! The structs here contain the items that get initialized.
+//! Each struct is initialized sequentially, one after the other.
+//! Each stage consumed the previous as a prerequisite.
+//! 
+//! If a peripheral is needed, it is included in the initialization process as late as possible.
+//! - If a problem occurs, it is easier to recover the further into initialization it is (e.g. boot to bootloader).
+//! - Other setups that do not need the full initialization can be more lean.
+//! 
+use core::ops::{Deref, DerefMut};
+
+use crate::hal;
+use hal::drivers::{
+    clocks::Clocks,
+    flash::FlashGordon,
+    pins::direction,
+    Timer
+};
+use hal::typestates::pin::state::Gpio;
+use hal::peripherals::{
+    prince::Prince,
+};
+use hal::peripherals::pfr::Pfr;
+use crate::types;
+
+/// Initialized clocks, Nfc interrupt pin, Iocon, Gpio.
+pub struct Clock {
+    pub clocks: Clocks,
+    pub nfc_irq: Option<hal::Pin<board::nfc::NfcIrqPin, Gpio<direction::Input>>>,
+    pub iocon: hal::Iocon<hal::Enabled>,
+    pub gpio: hal::Gpio<hal::Enabled>,
+
+    // prevent outside sources from constructing
+    pub(crate) _clock: (),
+}
+
+/// Initialized delay & performance timers, Adc, Buttons, Nfc chip, RGB LED
+pub struct Basic {
+    pub clock_stage: Clock,
+
+    pub delay_timer: Timer<hal::peripherals::ctimer::Ctimer0<hal::Enabled>>,
+    pub perf_timer: Timer<hal::peripherals::ctimer::Ctimer4<hal::Enabled>>,
+    pub pfr: Pfr<hal::Enabled>,
+
+    pub adc: Option<hal::Adc<hal::Enabled>>,
+    pub three_buttons: Option<board::ThreeButtons>,
+    pub rgb: Option<board::RgbLed>,
+}
+
+/// Initialized NFC Iso14443 transport
+pub struct Nfc {
+    pub basic_stage: Basic,
+    pub iso14443: Option<nfc_device::Iso14443<board::nfc::NfcChip>>,
+
+    pub contactless_responder: Option<interchange::Responder<apdu_dispatch::interchanges::Contactless>>,
+}
+
+/// Initialized USB device + USB classes, Dynamic Clock controller.
+pub struct Usb {
+    pub nfc_stage: Nfc,
+    pub usb_classes: Option<types::UsbClasses>,
+
+    pub contact_responder: Option<interchange::Responder<apdu_dispatch::interchanges::Contact>>,
+    pub ctaphid_responder: Option<interchange::Responder<ctaphid_dispatch::types::HidInterchange>>,
+}
+
+/// Initialized apdu + ctaphid dispatches
+pub struct Interfaces {
+    pub usb_stage: Usb,
+    pub apdu_dispatch: types::ApduDispatch,
+    pub ctaphid_dispatch: types::CtaphidDispatch,
+}
+
+/// Initialized flash driver, prince, RNG.
+pub struct Flash {
+    pub interfaces_stage: Interfaces,
+    pub flash_gordon: Option<FlashGordon>,
+    pub prince: Option<Prince<hal::Enabled>>,
+    pub rng: Option<hal::peripherals::rng::Rng<hal::Enabled>>,
+}
+
+/// Initialized filesystem.
+pub struct Filesystem {
+    pub flash_stage: Flash,
+    pub store: types::Store,
+    pub internal_storage_fs: &'static mut Option<types::FlashStorage>,
+}
+
+/// Initialized Trussed
+pub struct Trussed
+{
+    pub filesystem_stage: Filesystem,
+    pub trussed: types::Trussed,
+}
+
+
+// Use Deref + DerefMut to make each stage appear to contain everything flattened.
+impl Deref for Trussed {
+    type Target = Filesystem;
+
+    fn deref(&self) -> &Self::Target { &self.filesystem_stage }
+}
+impl DerefMut for Trussed {
+    fn deref_mut(&mut self) -> &mut Self::Target {  &mut self.filesystem_stage }
+}
+
+impl Deref for Filesystem {
+    type Target = Flash;
+
+    fn deref(&self) -> &Self::Target { &self.flash_stage }
+}
+impl DerefMut for Filesystem {
+    fn deref_mut(&mut self) -> &mut Self::Target {  &mut self.flash_stage  }
+}
+
+impl Deref for Flash {
+    type Target = Interfaces;
+
+    fn deref(&self) -> &Self::Target { &self.interfaces_stage }
+}
+impl DerefMut for Flash {
+    fn deref_mut(&mut self) -> &mut Self::Target {  &mut self.interfaces_stage  }
+}
+
+impl Deref for Interfaces {
+    type Target = Usb;
+
+    fn deref(&self) -> &Self::Target { &self.usb_stage }
+}
+impl DerefMut for Interfaces{
+    fn deref_mut(&mut self) -> &mut Self::Target {  &mut self.usb_stage }
+}
+
+impl Deref for Usb {
+    type Target = Nfc;
+
+    fn deref(&self) -> &Self::Target { &self.nfc_stage }
+}
+impl DerefMut for Usb {
+    fn deref_mut(&mut self) -> &mut Self::Target {  &mut self.nfc_stage  }
+}
+
+impl Deref for Nfc {
+    type Target = Basic;
+
+    fn deref(&self) -> &Self::Target { &self.basic_stage }
+}
+impl DerefMut for Nfc {
+    fn deref_mut(&mut self) -> &mut Self::Target {  &mut self.basic_stage  }
+}
+
+impl Deref for Basic {
+    type Target = Clock;
+
+    fn deref(&self) -> &Self::Target { &self.clock_stage }
+}
+impl DerefMut for Basic {
+    fn deref_mut(&mut self) -> &mut Self::Target {  &mut self.clock_stage  }
+}
+

--- a/runners/lpc55/src/lib.rs
+++ b/runners/lpc55/src/lib.rs
@@ -4,56 +4,24 @@ include!(concat!(env!("OUT_DIR"), "/build_constants.rs"));
 // panic handler, depending on debug/release build
 // BUT: need to run in release anyway, to have USB work
 use panic_halt as _;
-// use panic_semihosting as _;
+use c_stubs as _;
+
+use usb_device::device::UsbVidPid;
+use board::clock_controller;
+pub use board::hal; // re-export for convenience
+
+#[allow(unused_imports)]
+use hal::drivers::timer::Elapsed;
+
+use types::Board;
 
 #[macro_use]
 extern crate delog;
 generate_macros!();
 
-use board::clock_controller;
-
-use c_stubs as _;
-
-// re-exports for convenience
-pub use board::hal;
-// pub use board::rt::entry;
-
 pub mod types;
+pub mod initializer;
 
-use types::{
-    Board,
-    EnabledUsbPeripheral,
-    ExternalStorage,
-    VolatileStorage,
-    Store,
-};
-
-use hal::drivers::timer::Elapsed;
-use hal::traits::wg::timer::Cancel;
-use trussed::platform::UserInterface;
-
-//
-// Board Initialization
-//
-
-use hal::drivers::{
-    flash::FlashGordon,
-    pins,
-    UsbBus,
-    Timer,
-    Pwm,
-};
-use hal::peripherals::pfr::Pfr;
-use board::traits::rgb_led::RgbLed;
-use board::traits::buttons::Press;
-use interchange::Interchange;
-use usbd_ccid::Ccid;
-use usbd_ctaphid::CtapHid;
-// use usbd_ctaphid::insecure::InsecureRamAuthenticator;
-use usb_device::device::{UsbDeviceBuilder, UsbVidPid};
-// bring traits in scope
-use hal::prelude::*;
-use hal::traits::wg::digital::v2::InputPin;
 
 // Logging
 #[derive(Debug)]
@@ -76,58 +44,6 @@ impl delog::Flusher for Flusher {
 delog!(Delogger, 16*1024, 3*1024, Flusher);
 static FLUSHER: Flusher = Flusher {};
 
-fn validate_cfpa(pfr: &mut Pfr<hal::typestates::init_state::Enabled>) {
-    let mut cfpa = pfr.read_latest_cfpa().unwrap();
-    let current_version: u32 = build_constants::CARGO_PKG_VERSION;
-    if cfpa.secure_fw_version < current_version || cfpa.ns_fw_version < current_version {
-        info!("updating cfpa from {} to {}", cfpa.secure_fw_version, current_version);
-
-        // All of these are monotonic counters.
-        cfpa.version += 1;
-        cfpa.secure_fw_version = current_version;
-        cfpa.ns_fw_version = current_version;
-        pfr.write_cfpa(&cfpa).unwrap();
-    } else {
-        info!("do not need to update cfpa version {}", cfpa.secure_fw_version);
-    }
-        // Unless encryption is explicity disabled, we require that PRINCE has been provisioned.
-    #[cfg(not(feature = "no-encrypted-storage"))]
-    assert!(
-        cfpa.key_provisioned(hal::peripherals::pfr::KeyType::PrinceRegion2)
-    );
-}
-
-fn get_serial_number() -> &'static str {
-    static mut SERIAL_NUMBER: heapless::String<heapless::consts::U36> = heapless::String(heapless::i::String::new());
-    use core::fmt::Write;
-    unsafe {
-        let uuid = crate::hal::uuid();
-        SERIAL_NUMBER.write_fmt(format_args!("{}", hexstr!(&uuid))).unwrap();
-        &SERIAL_NUMBER
-    }
-}
-
-// SoloKeys stores a product string in the first 64 bytes of CMPA.
-fn get_product_string(pfr: &mut Pfr<hal::typestates::init_state::Enabled>) -> &'static str {
-    let data = pfr.cmpa_customer_data();
-
-    // check the first 64 bytes of customer data for a string
-    if data[0] != 0 {
-        for i in 1 .. 64 {
-            if data[i] == 0 {
-                let str_maybe = core::str::from_utf8(&data[0 .. i]);
-                if let Ok(string) = str_maybe {
-                    return string;
-                }
-                break;
-            }
-        }
-    }
-
-    // Use a default string
-    "Solo 2 (custom)"
-}
-
 // TODO: move board-specifics to BSPs
 pub fn init_board(
     device_peripherals: hal::raw::Peripherals,
@@ -135,7 +51,7 @@ pub fn init_board(
 ) -> (
     // types::Authenticator,
     types::ApduDispatch,
-    types::CtaphidDispach,
+    types::CtaphidDispatch,
     types::Trussed,
 
     types::Apps,
@@ -152,365 +68,87 @@ pub fn init_board(
 
     Delogger::init_default(delog::LevelFilter::Debug, &FLUSHER).ok();
     info_now!("entering init_board");
-
     let hal = hal::Peripherals::from((device_peripherals, core_peripherals));
-
-    let mut anactrl = hal.anactrl;
-    let mut pmc = hal.pmc;
-    let mut syscon = hal.syscon;
-
-    let mut gpio = hal.gpio.enabled(&mut syscon);
-    let mut iocon = hal.iocon.enabled(&mut syscon);
-
-    let nfc_irq = types::NfcIrqPin::take().unwrap().into_gpio_pin(&mut iocon, &mut gpio).into_input();
-    // Need to enable pullup for NFC IRQ input.
-    let iocon = iocon.release();
-    iocon.pio0_19.modify(|_,w| { w.mode().pull_up() } );
-    let mut iocon = hal::Iocon::from(iocon).enabled(&mut syscon);
-    let is_passive_mode = nfc_irq.is_low().ok().unwrap();
-
-    // Start out with slow clock if in passive mode;
-    let (mut clocks, adc) = if is_passive_mode {
-        let clocks = hal::ClockRequirements::default()
-            .system_frequency(4.MHz())
-            .configure(&mut anactrl, &mut pmc, &mut syscon)
-            .expect("Clock configuration failed");
-
-        // important to start Adc early in passive mode
-        let adc = hal::Adc::from(hal.adc)
-            .configure(clock_controller::DynamicClockController::adc_configuration())
-            .enabled(&mut pmc, &mut syscon);
-        (clocks, adc)
-    } else {
-        let clocks = hal::ClockRequirements::default()
-            .system_frequency(96.MHz())
-            .configure(&mut anactrl, &mut pmc, &mut syscon)
-            .expect("Clock configuration failed");
-
-        let adc = hal::Adc::from(hal.adc)
-            .enabled(&mut pmc, &mut syscon);
-
-
-        (clocks, adc)
-    };
-
-    let mut delay_timer = Timer::new(hal.ctimer.0.enabled(&mut syscon, clocks.support_1mhz_fro_token().unwrap()));
-    let mut perf_timer = Timer::new(hal.ctimer.4.enabled(&mut syscon, clocks.support_1mhz_fro_token().unwrap()));
-    perf_timer.start(60_000_000.microseconds());
-
-    #[cfg(feature = "board-lpcxpresso55")]
-    let mut rgb = board::RgbLed::new(
-        Pwm::new(hal.ctimer.2.enabled(&mut syscon, clocks.support_1mhz_fro_token().unwrap())),
-        &mut iocon,
-    );
-
-    #[cfg(feature = "board-solo2")]
-    let mut rgb = board::RgbLed::new(
-        Pwm::new(hal.ctimer.3.enabled(&mut syscon, clocks.support_1mhz_fro_token().unwrap())),
-        &mut iocon,
-    );
-
-    let (three_buttons,adc) = if is_passive_mode {
-        (None, Some(adc))
-    } else {
-        #[cfg(feature = "board-lpcxpresso55")]
-        let three_buttons = board::ThreeButtons::new(
-            Timer::new(hal.ctimer.1.enabled(&mut syscon, clocks.support_1mhz_fro_token().unwrap())),
-            &mut gpio,
-            &mut iocon,
-        );
-
-        #[cfg(feature = "board-solo2")]
-        let three_buttons =
-        {
-            let mut dma = hal::Dma::from(hal.dma).enabled(&mut syscon);
-
-            board::ThreeButtons::new (
-                adc,
-                hal.ctimer.1.enabled(&mut syscon, clocks.support_1mhz_fro_token().unwrap()),
-                hal.ctimer.2.enabled(&mut syscon, clocks.support_1mhz_fro_token().unwrap()),
-                &mut dma,
-                clocks.support_touch_token().unwrap(),
-                &mut gpio,
-                &mut iocon,
-            )
-        };
-
-        // Boot to bootrom if buttons are all held for 5s
-        info!("button start {}",perf_timer.elapsed().0/1000);
-        delay_timer.start(5_000_000.microseconds());
-        while three_buttons.is_pressed(board::traits::buttons::Button::A) &&
-              three_buttons.is_pressed(board::traits::buttons::Button::B) &&
-              three_buttons.is_pressed(board::traits::buttons::Button::Middle) {
-            // info!("3 buttons pressed..");
-            if delay_timer.wait().is_ok() {
-                // Give a small red blink show success
-                rgb.red(200);
-                rgb.green(0);
-                rgb.blue(0);
-                delay_timer.start(100_000.microseconds()); nb::block!(delay_timer.wait()).ok();
-                board::hal::boot_to_bootrom()
-            }
-        }
-        delay_timer.cancel().ok();
-
-        info!("button end {}",perf_timer.elapsed().0/1000);
-        (Some(three_buttons), None)
-    };
-
-    let mut pfr = hal.pfr.enabled(&clocks).unwrap();
-    validate_cfpa(&mut pfr);
-
-
-    let (contactless_requester, contactless_responder) = apdu_dispatch::interchanges::Contactless::claim()
-        .expect("could not setup iso14443 ApduInterchange");
-    let mut iso14443 = {
-        let token = clocks.support_flexcomm_token().unwrap();
-        let spi = hal.flexcomm.0.enabled_as_spi(&mut syscon, &token);
-
-        // Set up external interrupt for NFC IRQ
-        let mut mux = hal.inputmux.enabled(&mut syscon);
-        let mut pint = hal.pint.enabled(&mut syscon);
-        pint.enable_interrupt(&mut mux, &nfc_irq, hal::peripherals::pint::Slot::Slot0, hal::peripherals::pint::Mode::ActiveLow);
-        mux.disabled(&mut syscon);
-
-        let force_nfc_reconfig = cfg!(feature = "reconfigure-nfc");
-
-        let maybe_fm = board::nfc::try_setup(
-            spi,
-            &mut gpio,
-            &mut iocon,
-            nfc_irq,
-            &mut delay_timer,
-            force_nfc_reconfig,
-        );
-
-        if let Ok(fm) = maybe_fm {
-            Some(nfc_device::Iso14443::new(fm, contactless_requester))
-        } else {
-            if is_passive_mode {
-                info!("Shouldn't get passive signal when there's no chip!");
-            }
-            None
-        }
-    };
-
-    if let Some(iso14443) = &mut iso14443 { iso14443.poll(); }
-    if is_passive_mode {
-        // Give a small delay to charge up capacitors
-        delay_timer.start(5_000.microseconds()); nb::block!(delay_timer.wait()).ok();
-    }
-    if let Some(iso14443) = &mut iso14443 { iso14443.poll(); }
-
-    let usb0_vbus_pin = pins::Pio0_22::take().unwrap()
-        .into_usb0_vbus_pin(&mut iocon);
-
-    #[allow(unused_mut)]
-    let mut rng = hal.rng.enabled(&mut syscon);
-
-    let prince = hal.prince.enabled(&mut rng);
-    prince.disable_all_region_2();
-
-    use littlefs2::fs::{Allocation, Filesystem};
-
-    let flash_gordon = FlashGordon::new(hal.flash.enabled(&mut syscon));
-
+    
     #[cfg(not(feature = "no-encrypted-storage"))]
-    let filesystem = types::PrinceFilesystem::new(flash_gordon, prince);
-
+    let require_prince = true;
     #[cfg(feature = "no-encrypted-storage")]
-    let filesystem = types::PlainFilesystem::new(flash_gordon);
+    let require_prince = false;
 
-    // temporarily increase clock for the storage mounting or else it takes a long time.
-    if is_passive_mode {
-        clocks = unsafe { hal::ClockRequirements::default()
-            .system_frequency(48.MHz())
-            .reconfigure(clocks, &mut pmc, &mut syscon) };
-    }
-    info!("mount start {} ms",perf_timer.elapsed().0/1000);
-    static mut INTERNAL_STORAGE: Option<types::FlashStorage> = None;
-    unsafe { INTERNAL_STORAGE.replace(filesystem); }
-    static mut INTERNAL_FS_ALLOC: Option<Allocation<types::FlashStorage>> = None;
-    unsafe { INTERNAL_FS_ALLOC = Some(Filesystem::allocate()); }
+    let config = initializer::Config {
+        secure_firmware_version: Some(build_constants::CARGO_PKG_VERSION),
+        nfc_enabled: true,
+        require_prince: require_prince,
+        boot_to_bootrom: true,
+        usb_config: Some(initializer::UsbConfig {
+            manufacturer_name: "SoloKeys",
+            product_name: initializer::UsbProductName::UsePfr,
+            vid_pid: UsbVidPid(0x1209, 0xbeee),
+        })
+    };
 
-    static mut EXTERNAL_STORAGE: ExternalStorage = ExternalStorage::new();
-    static mut EXTERNAL_FS_ALLOC: Option<Allocation<ExternalStorage>> = None;
-    unsafe { EXTERNAL_FS_ALLOC = Some(Filesystem::allocate()); }
+    let mut initializer = initializer::Initializer::new(config, hal.syscon, hal.pmc, hal.anactrl);
 
-    static mut VOLATILE_STORAGE: VolatileStorage = VolatileStorage::new();
-    static mut VOLATILE_FS_ALLOC: Option<Allocation<VolatileStorage>> = None;
-    unsafe { VOLATILE_FS_ALLOC = Some(Filesystem::allocate()); }
+    let mut final_stage = initializer.initialize_all(
+        hal.iocon,
+        hal.gpio,
+        hal.adc,
+        hal.dma,
+        hal.ctimer.0,
+        hal.ctimer.1,
+        hal.ctimer.2,
+        hal.ctimer.3,
+        hal.ctimer.4,
+        hal.pfr,
+        hal.flexcomm.0,
+        hal.inputmux,
+        hal.pint,
+        hal.usbhs,
+        hal.usbfs,
+        hal.rng,
+        hal.prince,
+        hal.flash,
 
 
-    let store = Store::claim().unwrap();
-
-    if let Some(iso14443) = &mut iso14443 { iso14443.poll(); }
-
-    let result = store.mount(
-        unsafe { INTERNAL_FS_ALLOC.as_mut().unwrap() },
-        // unsafe { &mut INTERNAL_STORAGE },
-        unsafe { INTERNAL_STORAGE.as_mut().unwrap() },
-        unsafe { EXTERNAL_FS_ALLOC.as_mut().unwrap() },
-        unsafe { &mut EXTERNAL_STORAGE },
-        unsafe { VOLATILE_FS_ALLOC.as_mut().unwrap() },
-        unsafe { &mut VOLATILE_STORAGE },
-        // to trash existing data, set to true
-        false,
+        hal.rtc,
     );
 
-
-    if result.is_err() || cfg!(feature = "format-filesystem") {
-        rgb.blue(200);
-        rgb.red(200);
-        delay_timer.start(300_000.microseconds()); nb::block!(delay_timer.wait()).ok();
-        info!("Not yet formatted!  Formatting..");
-        store.mount(
-            unsafe { INTERNAL_FS_ALLOC.as_mut().unwrap() },
-            // unsafe { &mut INTERNAL_STORAGE },
-            unsafe { INTERNAL_STORAGE.as_mut().unwrap() },
-            unsafe { EXTERNAL_FS_ALLOC.as_mut().unwrap() },
-            unsafe { &mut EXTERNAL_STORAGE },
-            unsafe { VOLATILE_FS_ALLOC.as_mut().unwrap() },
-            unsafe { &mut VOLATILE_STORAGE },
-            // to trash existing data, set to true
-            true,
-        ).unwrap();
-    }
-    info!("mount end {} ms",perf_timer.elapsed().0/1000);
-
-    // return to slow freq
-    if is_passive_mode {
-        clocks = unsafe { hal::ClockRequirements::default()
-            .system_frequency(12.MHz())
-            .reconfigure(clocks, &mut pmc, &mut syscon) };
-        // // Give some feedback to user that token is in field
-        // rgb.red(30);
-    }
-
-    if let Some(iso14443) = &mut iso14443 { iso14443.poll(); }
-
-    let (contact_requester, contact_responder) = apdu_dispatch::interchanges::Contact::claim()
-        .expect("could not setup ccid ApduInterchange");
-
-    let (hid_requester, hid_responder) = ctaphid_dispatch::types::HidInterchange::claim()
-        .expect("could not setup HidInterchange");
-
-    info!("usb class start {} ms",perf_timer.elapsed().0/1000);
-    let usb_classes =
-    {
-        if !is_passive_mode {
-            #[cfg(not(feature = "usbfs-peripheral"))]
-            let mut usbd = hal.usbhs.enabled_as_device(
-                &mut anactrl,
-                &mut pmc,
-                &mut syscon,
-                &mut delay_timer,
-                clocks.support_usbhs_token().unwrap(),
-            );
-            #[cfg(feature = "usbfs-peripheral")]
-            let usbd = hal.usbfs.enabled_as_device(
-                &mut anactrl,
-                &mut pmc,
-                &mut syscon,
-                clocks.support_usbfs_token().unwrap(),
-            );
-            #[cfg(not(any(feature = "highspeed", feature = "usbfs-peripheral")))]
-            usbd.disable_high_speed();
-            let _: EnabledUsbPeripheral = usbd;
-
-            // ugh, what's the nice way?
-            static mut USB_BUS: Option<usb_device::bus::UsbBusAllocator<UsbBus<EnabledUsbPeripheral>>> = None;
-            unsafe { USB_BUS.replace(hal::drivers::UsbBus::new(usbd, usb0_vbus_pin)); }
-            let usb_bus = unsafe { USB_BUS.as_ref().unwrap() };
-
-            // our USB classes (must be allocated in order that they're passed in `.poll(...)` later!)
-            let ccid = Ccid::new(usb_bus, contact_requester);
-            let ctaphid = CtapHid::new(usb_bus, hid_requester, perf_timer.elapsed().0/1000)
-                .implements_ctap1()
-                .implements_ctap2()
-                .implements_wink();
-
-            let serial = usbd_serial::SerialPort::new(usb_bus);
-
-            // Only 16 bits, so take the upper bits of our semver
-            let device_release =
-                ((build_constants::CARGO_PKG_VERSION_MAJOR as u16) << 8) |
-                (build_constants::CARGO_PKG_VERSION_MINOR as u16);
-
-            // our composite USB device
-            let product_string = get_product_string(&mut pfr);
-            let serial_number = get_serial_number();
-
-            let usbd = UsbDeviceBuilder::new(usb_bus, UsbVidPid(0x1209, 0xbeee))
-                .manufacturer("SoloKeys")
-                .product(product_string)
-                .serial_number(serial_number)
-                .device_release(device_release)
-                .max_packet_size_0(64)
-                .composite_with_iads()
-                .build();
-
-            Some(types::UsbClasses::new(usbd, ccid, ctaphid, /*keyboard,*/ serial))
-        } else {
-            None
-        }
-    };
-
-    let mut rtc = hal.rtc.enabled(&mut syscon, clocks.enable_32k_fro(&mut pmc));
-    rtc.reset();
-
-    let rgb = if is_passive_mode {
-        None
-    } else {
-        Some(rgb)
-    };
-
-    let clock_controller = if is_passive_mode {
-        let mut clock_controller = clock_controller::DynamicClockController::new(adc.unwrap(),
-            clocks, pmc, syscon, &mut gpio, &mut iocon);
-        clock_controller.start_high_voltage_compare();
-        Some(clock_controller)
-    } else {
-        None
-    };
-
-    let mut solobee_interface = board::trussed::UserInterface::new(rtc, three_buttons, rgb);
-    solobee_interface.set_status(trussed::platform::ui::Status::Idle);
-
-    let board = Board::new(rng, store, solobee_interface);
-    let mut trussed = trussed::service::Service::new(board);
-
-    let apdu_dispatch = types::ApduDispatch::new(contact_responder, contactless_responder);
-    let ctaphid_dispatch = types::CtaphidDispach::new(hid_responder);
+    let _is_passive_mode = initializer.is_in_passive_operation(&final_stage);
+    let clock_controller = initializer.get_dynamic_clock_control(&mut final_stage);
 
     // rgb.turn_off();
-    delay_timer.cancel().ok();
-    info!("init took {} ms",perf_timer.elapsed().0/1000);
+    info!("init took {} ms", final_stage.perf_timer.elapsed().0/1000);
+
+    #[cfg(feature = "provisioner-app")]
+    let store = final_stage.store.clone();
+    #[cfg(feature = "provisioner-app")]
+    let internal_fs = final_stage.filesystem_stage.internal_storage_fs;
 
     let apps = types::Apps::new(
-        &mut trussed,
+        &mut final_stage.trussed,
         #[cfg(feature = "provisioner-app")]
         {
             types::ProvisionerNonPortable {
                 store,
-                stolen_filesystem: unsafe { INTERNAL_STORAGE.as_mut().unwrap() },
-                nfc_powered: is_passive_mode,
+                stolen_filesystem: internal_fs.as_mut().unwrap(),
+                nfc_powered: _is_passive_mode,
             }
         }
     );
 
     (
-        apdu_dispatch,
-        ctaphid_dispatch,
-        trussed,
+        final_stage.filesystem_stage.flash_stage.interfaces_stage.apdu_dispatch,
+        final_stage.filesystem_stage.flash_stage.interfaces_stage.ctaphid_dispatch,
+        final_stage.trussed,
 
         apps,
 
-        usb_classes,
-        iso14443,
+        final_stage.filesystem_stage.flash_stage.interfaces_stage.usb_stage.usb_classes,
+        final_stage.filesystem_stage.flash_stage.interfaces_stage.usb_stage.nfc_stage.iso14443,
 
-        perf_timer,
+        final_stage.filesystem_stage.flash_stage.interfaces_stage.usb_stage.nfc_stage.basic_stage.perf_timer,
         clock_controller,
-        delay_timer,
+
+        final_stage.filesystem_stage.flash_stage.interfaces_stage.usb_stage.nfc_stage.basic_stage.delay_timer,
     )
 }

--- a/runners/lpc55/src/main.rs
+++ b/runners/lpc55/src/main.rs
@@ -7,7 +7,7 @@
 // #![deny(warnings)]
 
 use core::convert::TryFrom;
-use app::hal;
+use runner::hal;
 use hal::traits::wg::timer::Cancel;
 use hal::traits::wg::timer::CountDown;
 use hal::drivers::timer::Elapsed;
@@ -25,23 +25,23 @@ const NFC_INTERRUPT: board::hal::raw::Interrupt = board::hal::raw::Interrupt::PI
 extern crate delog;
 generate_macros!();
 
-#[rtic::app(device = app::hal::raw, peripherals = true, monotonic = rtic::cyccnt::CYCCNT)]
+#[rtic::app(device = runner::hal::raw, peripherals = true, monotonic = rtic::cyccnt::CYCCNT)]
 const APP: () = {
 
     struct Resources {
-        apdu_dispatch: app::types::ApduDispatch,
-        ctaphid_dispatch: app::types::CtaphidDispach,
-        trussed: app::types::Trussed,
+        apdu_dispatch: runner::types::ApduDispatch,
+        ctaphid_dispatch: runner::types::CtaphidDispatch,
+        trussed: runner::types::Trussed,
 
-        apps: app::types::Apps,
+        apps: runner::types::Apps,
 
-        usb_classes: Option<app::types::UsbClasses>,
-        contactless: Option<app::types::Iso14443>,
+        usb_classes: Option<runner::types::UsbClasses>,
+        contactless: Option<runner::types::Iso14443>,
 
-        perf_timer: app::types::PerfTimer,
+        perf_timer: runner::types::PerfTimer,
 
-        clock_ctrl: Option<app::types::DynamicClockController>,
-        hw_scheduler: app::types::HwScheduler,
+        clock_ctrl: Option<runner::types::DynamicClockController>,
+        hw_scheduler: runner::types::HwScheduler,
     }
 
     #[init(schedule = [update_ui])]
@@ -60,7 +60,7 @@ const APP: () = {
             perf_timer,
             clock_ctrl,
             hw_scheduler,
-        ) = app::init_board(c.device, c.core);
+        ) = runner::init_board(c.device, c.core);
 
         // don't toggle LED in passive mode
         if usb_classes.is_some() {
@@ -110,7 +110,7 @@ const APP: () = {
                 }
             });
             if time > 1_200_000 {
-                app::Delogger::flush();
+                runner::Delogger::flush();
             }
 
             match apps.apdu_dispatch(|apps| apdu_dispatch.poll(apps)) {

--- a/runners/lpc55/src/types.rs
+++ b/runners/lpc55/src/types.rs
@@ -2,7 +2,7 @@ include!(concat!(env!("OUT_DIR"), "/build_constants.rs"));
 use core::convert::TryInto;
 
 use crate::hal;
-use hal::drivers::{pins, timer};
+use hal::drivers::timer;
 use interchange::Interchange;
 use littlefs2::const_ram_storage;
 use trussed::types::{LfsResult, LfsStorage};
@@ -79,19 +79,12 @@ impl trussed::client::Syscall for Syscall {
 pub type Trussed = trussed::Service<Board>;
 pub type TrussedClient = trussed::ClientImplementation<Syscall>;
 
-pub type NfcSckPin = pins::Pio0_28;
-pub type NfcMosiPin = pins::Pio0_24;
-pub type NfcMisoPin = pins::Pio0_25;
-pub type NfcCsPin = pins::Pio1_20;
-pub type NfcIrqPin = pins::Pio0_19;
-
-// pub use board::NfcChip;
 pub type Iso14443 = nfc_device::Iso14443<board::nfc::NfcChip>;
 
 pub type ExternalInterrupt = hal::Pint<hal::typestates::init_state::Enabled>;
 
 pub type ApduDispatch = apdu_dispatch::dispatch::ApduDispatch;
-pub type CtaphidDispach = ctaphid_dispatch::dispatch::Dispatch;
+pub type CtaphidDispatch = ctaphid_dispatch::dispatch::Dispatch;
 
 #[cfg(feature = "admin-app")]
 pub type AdminApp = admin_app::App<TrussedClient>;


### PR DESCRIPTION
Refactors the mess of lib.rs into a cleaner and reusable form.  

initialization can be done in stages, or all at once.  The details of running passively or not, and the timing, are abstracted.

An example of initializing, stopping before initializing filesystem and trussed.

```rust
    let config = initializer::Config {
        secure_firmware_version: None,
        nfc_enabled: true,
        require_prince: false,
        boot_to_bootrom: true,
        usb_config: Some(initializer::UsbConfig {
            manufacturer_name: "SoloKeys",
            product_name: initializer::UsbProductName::Custom("Provisioner"),
            vid_pid: UsbVidPid(0x1209, 0xb002),
        })
    };

    let mut initializer = initializer::Initializer::new(config, hal.syscon, hal.pmc, hal.anactrl);

    let clock_stage = initializer.initialize_clocks(hal.iocon, hal.gpio,);
    let basic_stage = initializer.initialize_basic(
        clock_stage,
        hal.adc,
        hal.dma,
        hal.ctimer.0,
        hal.ctimer.1,
        hal.ctimer.2,
        hal.ctimer.3,
        hal.ctimer.4,
        hal.pfr,
    );
    let nfc_stage = initializer.initialize_nfc(basic_stage, hal.flexcomm.0, hal.inputmux, hal.pint);

    let usb_stage = initializer.initialize_usb(nfc_stage, hal.usbhs, hal.usbfs);
    let mut interfaces_stage = initializer.initialize_interfaces(usb_stage);

    // do some custom initialization if needed
    // ...

    let filesystem_stage = initializer.initialize_filesystem(flash_stage);

    let is_passive_mode = initializer.is_in_passive_operation(&filesystem_stage);

    let tester_interface = tester_trussed::UserInterface::new();
    let board = types::ProvisionerBoard::new(
        filesystem_stage.flash_stage.rng.unwrap(),
        filesystem_stage.store,
        tester_interface,
    );
    let mut trussed: trussed::Service<types::ProvisionerBoard> = trussed::service::Service::new(board);

```