### PR TITLE
Ctaphid keepalive

### DIFF
--- a/components/dispatch-fido/src/fido.rs
+++ b/components/dispatch-fido/src/fido.rs
@@ -274,7 +274,7 @@ where UP: UserPresence,
                 let result = self.call_authenticator_u2f_with_bytes(request, response);
                 match result {
                     Ok(()) => {
-                        info!("U2F response {} bytes", data.len());
+                        info!("U2F response {} bytes", response.len());
                         // Need to add x9000 success code (normally the apdu-dispatch does this, but
                         // since u2f uses apdus over hid, we must do it here.)
                         response.extend_from_slice(&[0x90, 0x00]).ok();

--- a/components/usbd-ctaphid/Cargo.toml
+++ b/components/usbd-ctaphid/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 ctap-types = { path = "../ctap-types" }
+embedded-time = "0.10.1"
 delog = "0.1.0"
 heapless = "0.6"
 heapless-bytes = "0.2.0"

--- a/components/usbd-ctaphid/src/class.rs
+++ b/components/usbd-ctaphid/src/class.rs
@@ -2,8 +2,10 @@
 // use core::convert::TryFrom as _;
 
 use interchange::Requester;
+use embedded_time::duration::Extensions;
 
 use crate::{
+    types::Status,
     constants::{INTERRUPT_POLL_MILLISECONDS, PACKET_SIZE},
     pipe::Pipe,
 };
@@ -79,6 +81,25 @@ where
     pub fn check_for_app_response(&mut self) {
         self.poll();
     }
+
+    /// Indicate whether or not a task should be scheduled to send keepalive messages.
+    pub fn did_start_processing(&mut self) -> Status {
+        if self.pipe.did_start_processing() {
+            Status::ReceivedData(250.milliseconds())
+        } else {
+            Status::Idle
+        }
+    }
+
+    /// Send a keep alive message with 1 of 2 possible statuses.
+    pub fn send_keepalive(&mut self, is_waiting_for_user_presence: bool) -> Status {
+        if self.pipe.send_keepalive(is_waiting_for_user_presence) {
+            Status::ReceivedData(250.milliseconds())
+        } else {
+            Status::Idle
+        }
+    }
+
 }
 
 const HID_INTERFACE_CLASS: u8 = 0x03;

--- a/components/usbd-ctaphid/src/lib.rs
+++ b/components/usbd-ctaphid/src/lib.rs
@@ -20,4 +20,5 @@ pub mod constants;
 pub mod class;
 pub use class::CtapHid;
 pub mod pipe;
+pub mod types;
 

--- a/components/usbd-ctaphid/src/types.rs
+++ b/components/usbd-ctaphid/src/types.rs
@@ -1,0 +1,15 @@
+
+use embedded_time::duration::Milliseconds;
+
+// Status to indicate Whether or not to send keepalive messages
+pub enum Status {
+    // No need
+    Idle,
+    // Should schedule take with given period in miliseconds
+    ReceivedData(Milliseconds),
+}
+
+pub enum KeepaliveStatus {
+    Processing = 1,
+    UpNeeded = 2,
+}

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -55,7 +55,7 @@ panic-halt = "0.2.0"
 # panic-semihosting = "0.5.6"
 
 # storage
-littlefs2 = "0.2.1"
+littlefs2 = "0.2.2"
 
 [features]
 default = ["admin-app", "fido-authenticator", "ndef-app", "oath-authenticator", "piv-authenticator", "trussed/clients-4"]

--- a/runners/lpc55/src/initializer.rs
+++ b/runners/lpc55/src/initializer.rs
@@ -292,7 +292,6 @@ impl Initializer {
 
     }
 
-    #[inline(never)]
     pub fn initialize_basic(&mut self,
         clock_stage: &mut stages::Clock,
         adc: hal::Adc<Unknown>,
@@ -394,7 +393,6 @@ impl Initializer {
         }
     }
 
-    #[inline(never)]
     pub fn initialize_nfc(&mut self,
         clock_stage: &mut stages::Clock,
         basic_stage: &mut stages::Basic,
@@ -445,7 +443,6 @@ impl Initializer {
 
     }
 
-    #[inline(never)]
     pub fn initialize_usb(
         &mut self,
         clock_stage: &mut stages::Clock,
@@ -544,7 +541,6 @@ impl Initializer {
         }
     }
 
-    #[inline(never)]
     pub fn initialize_interfaces(&mut self, nfc_stage: &mut stages::Nfc, usb_stage: &mut stages::Usb) -> stages::Interfaces {
 
         info_now!("making interfaces");
@@ -586,7 +582,6 @@ impl Initializer {
         }
     }
 
-    #[inline(never)]
     pub fn initialize_filesystem(&mut self,
         clock_stage: &mut stages::Clock,
         basic_stage: &mut stages::Basic,
@@ -630,13 +625,7 @@ impl Initializer {
         static mut INTERNAL_STORAGE: Option<types::FlashStorage> = None;
         unsafe { INTERNAL_STORAGE.replace(filesystem); }
         static mut INTERNAL_FS_ALLOC: Option<Allocation<types::FlashStorage>> = None;
-        unsafe {
-            info_now!("internal fs alloc {:?}", INTERNAL_FS_ALLOC.is_some());
-        }
         unsafe { INTERNAL_FS_ALLOC = Some(Filesystem::allocate()); }
-        unsafe {
-            info_now!("internal fs alloc {:?}", INTERNAL_FS_ALLOC.is_some());
-        }
 
 
         static mut EXTERNAL_STORAGE: ExternalStorage = ExternalStorage::new();
@@ -712,8 +701,6 @@ impl Initializer {
             internal_storage_fs: unsafe { &mut INTERNAL_STORAGE },
         }
     }
-
-
 
     pub fn initialize_trussed(
         &mut self,

--- a/runners/lpc55/src/lib.rs
+++ b/runners/lpc55/src/lib.rs
@@ -121,7 +121,7 @@ pub fn init_board(
     info!("init took {} ms", everything.basic.perf_timer.elapsed().0/1000);
 
     #[cfg(feature = "provisioner-app")]
-    let store = everything.store.clone();
+    let store = everything.filesystem.store.clone();
     #[cfg(feature = "provisioner-app")]
     let internal_fs = everything.filesystem.internal_storage_fs;
 


### PR DESCRIPTION
Adds keepalive reporting support to fido2.  Without it, you have about .5 seconds before windows gives up on your key :)

Implementation mirrors the wait extension requests for CCID and ISO14443.  One extra is I added this side channel to `board::trussed` so it knows whether to report waiting on UP or processing.

https://github.com/solokeys/solo2/compare/ctaphid-keepalive?expand=1#diff-6449354ce711c4a5ab2d6a0791c2f0346329d56b2df5b310e70e67cde3748be4R34-R89