### PR TITLE
Tweaks to the admin app's Reboot trait

### DIFF
--- a/components/admin-app/src/lib.rs
+++ b/components/admin-app/src/lib.rs
@@ -6,5 +6,5 @@
 //! It directly implements the APDU and CTAPHID dispatch App interfaces.
 #![no_std]
 
-pub mod management;
-pub use management::*;
+mod admin;
+pub use admin::{App, Reboot};


### PR DESCRIPTION
- use PhantomData instead of unused None option
- make naming a little more descriptive
- add documentation