### PR TITLE
Fix features for build-dev target

### DIFF
--- a/runners/lpc55/Makefile
+++ b/runners/lpc55/Makefile
@@ -6,7 +6,7 @@ PROVISIONER := --features board-$(BOARD),develop-provisioner
 # i.e., no encrypted storage, etc.
 build-dev:
 	cargo build --release $(DEVELOP)
-	cargo objcopy --release $(PROVISIONER) -- -O binary app.bin
+	cargo objcopy --release $(DEVELOP) -- -O binary app.bin
 
 # builds firmware bundle as before, *including* provisioner app
 build-pro:


### PR DESCRIPTION
The Makefile in runners/lpc55 contained used the $(PROVISIONER) features
instead of the $(DEVELOP) features when calling cargo objcopy for the
build-dev target.