### PR TITLE
Add *.bin to gitignore in runners/lpc55

### DIFF
--- a/runners/lpc55/.gitignore
+++ b/runners/lpc55/.gitignore
@@ -1,4 +1,5 @@
 target
 Cargo.lock
+*.bin
 *.elf
 lpc55s69.pack


### PR DESCRIPTION
The Makefile now generates firmware images with the bin suffix in
runners/lpc55.  This patch adds these files to the gitignore file.