### PR TITLE
Bump heapless and all that bumped it

### DIFF
--- a/components/admin-app/src/admin.rs
+++ b/components/admin-app/src/admin.rs
@@ -1,8 +1,7 @@
 use core::{convert::TryInto, marker::PhantomData};
 use ctaphid_dispatch::app::{self as hid, Command as HidCommand, Message};
 use ctaphid_dispatch::command::VendorCommand;
-use apdu_dispatch::{Command, response, app as apdu};
-use apdu_dispatch::{command::Size as CommandSize, response::Size as ResponseSize};
+use apdu_dispatch::{Command, command, response, app as apdu};
 use apdu_dispatch::iso7816::Status;
 use trussed::{
     syscall,
@@ -120,20 +119,17 @@ where T: TrussedClient,
     }
 }
 
-impl<T, R> apdu::Aid for App<T, R>
+impl<T, R> iso7816::App for App<T, R>
 where T: TrussedClient,
       R: Reboot
 {
     // Solo management app
-    fn aid(&self) -> &'static [u8] {
-        &[ 0xA0, 0x00, 0x00, 0x08, 0x47, 0x00, 0x00, 0x00, 0x01]
-    }
-    fn right_truncated_length(&self) -> usize {
-        9
+    fn aid(&self) -> iso7816::Aid {
+        iso7816::Aid::new(&[ 0xA0, 0x00, 0x00, 0x08, 0x47, 0x00, 0x00, 0x00, 0x01])
     }
 }
 
-impl<T, R> apdu::App<CommandSize, ResponseSize> for App<T, R>
+impl<T, R> apdu::App<{command::SIZE}, {response::SIZE}> for App<T, R>
 where T: TrussedClient,
       R: Reboot
 {

--- a/components/ctaphid-dispatch/Cargo.toml
+++ b/components/ctaphid-dispatch/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 
 [dependencies]
 delog = "0.1.0"
-heapless = "0.6"
-heapless-bytes = "0.2.0"
+heapless = "0.7"
+heapless-bytes = "0.3"
 interchange = "0.2.0"
 
 [features]

--- a/components/ctaphid-dispatch/src/types.rs
+++ b/components/ctaphid-dispatch/src/types.rs
@@ -6,13 +6,13 @@ pub enum Error {
     InvalidLength,
 }
 
-// 7609 bytes is max message size for ctaphid
-type U6144 = <heapless::consts::U4096 as core::ops::Add<heapless::consts::U2048>>::Output;
-type U7168 = <U6144 as core::ops::Add<heapless::consts::U1024>>::Output;
-pub type U7609 = <U7168 as core::ops::Add<heapless::consts::U441>>::Output;
+// // 7609 bytes is max message size for ctaphid
+// type U6144 = <heapless::consts::U4096 as core::ops::Add<heapless::consts::U2048>>::Output;
+// type U7168 = <U6144 as core::ops::Add<heapless::consts::U1024>>::Output;
+// pub type U7609 = <U7168 as core::ops::Add<heapless::consts::U441>>::Output;
 // pub type U7609 = heapless::consts::U4096;
 
-pub type Message = heapless_bytes::Bytes<U7609>;
+pub type Message = heapless::Vec<u8, 7609>;
 pub type AppResult = core::result::Result<(), Error>;
 pub type InterchangeResponse = core::result::Result<Message, Error>;
 

--- a/components/dispatch-fido/Cargo.toml
+++ b/components/dispatch-fido/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 delog = "0.1.0"
 heapless = "0.6"
-heapless-bytes = "0.2.0"
+heapless-bytes = "0.3"
 interchange = "0.2.0"
 serde = { version = "1", default-features = false }
 

--- a/components/dispatch-fido/src/fido.rs
+++ b/components/dispatch-fido/src/fido.rs
@@ -37,7 +37,7 @@ where UP: UserPresence,
     }
 
     fn response_from_object<T: serde::Serialize>(&mut self, object: Option<T>, reply: &mut response::Data) -> app::Result {
-        reply.resize_to_capacity();
+        reply.resize_default(reply.capacity()).ok();
         if let Some(object) = object {
             match cbor_serialize(&object, &mut reply[1..]) {
                 Ok(ser) => {
@@ -144,18 +144,18 @@ where UP: UserPresence,
 
 }
 
-impl<UP, T> app::Aid for Fido<UP, T>
+impl<UP, T> iso7816::App for Fido<UP, T>
 where UP: UserPresence,
 {
-    fn aid(&self) -> &'static [u8] {
-        &[ 0xA0, 0x00, 0x00, 0x06, 0x47, 0x2F, 0x00, 0x01 ]
-    }
-    fn right_truncated_length(&self) -> usize {
-        8
+    fn aid(&self) -> iso7816::Aid {
+        iso7816::Aid::new(&[ 0xA0, 0x00, 0x00, 0x06, 0x47, 0x2F, 0x00, 0x01])
     }
 }
 
-impl<UP, T> app::App<apdu_dispatch::command::Size, apdu_dispatch::response::Size> for Fido<UP, T>
+impl<UP, T> app::App<
+    {apdu_dispatch::command::SIZE},
+    {apdu_dispatch::response::SIZE},
+> for Fido<UP, T>
 where UP: UserPresence,
       T: client::Client
        + client::P256

--- a/components/fm11nc08/Cargo.toml
+++ b/components/fm11nc08/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 delog = "0.1.0"
-embedded-time = "0.10.1"
+embedded-time = "0.12"
 embedded-hal = { version = "0.2.5", features = ["unproven"] }
 nb = "1"
 nfc-device = {path = "../nfc-device"}

--- a/components/ndef-app/Cargo.toml
+++ b/components/ndef-app/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-heapless = "0.6"
-heapless-bytes = "0.2.0"
+heapless = "0.7"
 
 apdu-dispatch = { git = "https://github.com/solokeys/apdu-dispatch", branch = "main" }
 iso7816 = { git = "https://github.com/ycrypto/iso7816", branch = "main" }

--- a/components/ndef-app/src/ndef.rs
+++ b/components/ndef-app/src/ndef.rs
@@ -1,5 +1,5 @@
 use iso7816::{Instruction, Status};
-use apdu_dispatch::{Command, response, app, command::Size as CommandSize, response::Size as ResponseSize};
+use apdu_dispatch::{Command, response, app, command::SIZE as CommandSize, response::SIZE as ResponseSize};
 
 pub struct App<'a>{
     reader: &'a [u8]
@@ -31,13 +31,9 @@ impl<'a> App<'a> {
     }
 }
 
-impl<'a> app::Aid for App<'a> {
-    fn aid(&self) -> &'static [u8] {
-        &[0xD2u8, 0x76, 0x00, 0x00, 0x85, 0x01, 0x01,]
-    }
-
-    fn right_truncated_length(&self) -> usize {
-        8
+impl<'a> iso7816::App for App<'a> {
+    fn aid(&self) -> iso7816::Aid {
+        iso7816::Aid::new(&[0xD2u8, 0x76, 0x00, 0x00, 0x85, 0x01, 0x01])
     }
 }
 

--- a/components/nfc-device/Cargo.toml
+++ b/components/nfc-device/Cargo.toml
@@ -6,9 +6,8 @@ edition = "2018"
 
 [dependencies]
 delog = "0.1.0"
-embedded-time = "0.10.1"
-heapless = "0.6"
-heapless-bytes = "0.2.0"
+embedded-time = "0.12"
+heapless = "0.7"
 nb = "1"
 
 apdu-dispatch = { git = "https://github.com/solokeys/apdu-dispatch", branch = "main" }

--- a/components/nfc-device/src/iso14443.rs
+++ b/components/nfc-device/src/iso14443.rs
@@ -2,7 +2,7 @@ use core::mem::MaybeUninit;
 
 use apdu_dispatch::interchanges;
 use embedded_time::duration::Milliseconds;
-use heapless_bytes::Bytes;
+use heapless::Vec;
 use interchange::Requester;
 
 use crate::traits::nfc;
@@ -21,7 +21,7 @@ pub enum Iso14443Status {
 }
 
 // Max iso14443 frame is 256 bytes
-type Iso14443Frame = heapless_bytes::Bytes<heapless::consts::U256>;
+type Iso14443Frame = Vec<u8, 256>;
 
 #[derive(Clone, PartialEq)]
 enum Iso14443State {
@@ -116,7 +116,7 @@ where
             wtx_requested: false,
             block_num: true,
 
-            buffer: Bytes::new(),
+            buffer: Vec::new(),
 
             interchange: interchange,
         }
@@ -192,7 +192,7 @@ where
                         Iso14443State::Transmitting(last_frame_range, _remaining_data_range) => {
                             info!("Retransmission requested..");
                             self.send_frame(
-                                &Bytes::try_from_slice(
+                                &Vec::from_slice(
                                     &self.buffer[last_frame_range]
                                 ).unwrap()
                             ).ok();
@@ -352,7 +352,7 @@ where
         debug!("{}", hex_str!(&self.buffer, sep:""));
         // logging::dump_hex(packet, l as usize);
 
-        let command = interchanges::Data::try_from_slice(&self.buffer);
+        let command = interchanges::Data::from_slice(&self.buffer);
         self.buffer.clear();
         if command.is_ok() {
             if self.interchange.request(

--- a/components/provisioner-app/Cargo.toml
+++ b/components/provisioner-app/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 apdu-dispatch = { git = "https://github.com/solokeys/apdu-dispatch", branch = "main" }
 delog = "0.1.1"
 heapless = "0.6"
-heapless-bytes = "0.2.0"
-lpc55-hal = { version = "0.2.1", features = ["littlefs", "rtic-peripherals"] }
+heapless-bytes = "0.3"
+lpc55-hal = { version = "0.3", features = ["littlefs", "rtic-peripherals"] }
 littlefs2 = "0.2.2"
 trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main" }
 

--- a/components/usbd-ccid/Cargo.toml
+++ b/components/usbd-ccid/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 
 [dependencies]
 delog = "0.1.0"
-embedded-time = "0.10.1"
-heapless = "0.6"
-heapless-bytes = "0.2.0"
+embedded-time = "0.12"
+heapless = "0.7"
+# heapless-bytes = "0.3"
 interchange = "0.2.0"
 iso7816 = { git = "https://github.com/ycrypto/iso7816", branch = "main" }
 usb-device = { version = "0.2.3", features = ["control-buffer-256"] }

--- a/components/usbd-ccid/src/constants.rs
+++ b/components/usbd-ccid/src/constants.rs
@@ -1,16 +1,8 @@
-#![allow(non_camel_case_types)]
-use heapless_bytes::{
-    consts,
-    Unsigned as _
-};
-
 // can be 8, 16, 32, 64 or 512
 #[cfg(feature = "highspeed-usb")]
-pub type PACKET_SIZE_TYPE = consts::U512;
+pub const PACKET_SIZE: usize = 512;
 #[cfg(not(feature = "highspeed-usb"))]
-pub type PACKET_SIZE_TYPE = consts::U64;
-
-pub const PACKET_SIZE: usize = PACKET_SIZE_TYPE::USIZE;
+pub const PACKET_SIZE: usize = 64;
 
 pub const CLASS_CCID: u8 = 0x0B;
 pub const SUBCLASS_NONE: u8 = 0x0;
@@ -46,8 +38,7 @@ pub const MAX_IFSD: [u8; 4] = [0xfe, 0x00, 0x00, 0x00];
 
 // "The value shall be between 261 + 10 and 65544 + 10
 // dwMaxCCIDMsgLen 3072
-pub type MAX_MSG_LENGTH_TYPE = <consts::U2048 as core::ops::Add<consts::U1024>>::Output;
-pub const MAX_MSG_LENGTH: usize = MAX_MSG_LENGTH_TYPE::USIZE;
+pub const MAX_MSG_LENGTH: usize = 3072;
 pub const MAX_MSG_LENGTH_LE: [u8; 4] = [0x00, 0x0C, 0x00, 0x00];
 
 pub const NUM_SLOTS: u8 = 1;

--- a/components/usbd-ccid/src/types/packet.rs
+++ b/components/usbd-ccid/src/types/packet.rs
@@ -3,8 +3,8 @@ use core::convert::TryInto;
 use crate::constants::*;
 
 
-pub type RawPacket = heapless_bytes::Bytes<PACKET_SIZE_TYPE>;
-pub type ExtPacket = heapless_bytes::Bytes<MAX_MSG_LENGTH_TYPE>;
+pub type RawPacket = heapless::Vec<u8, PACKET_SIZE>;
+pub type ExtPacket = heapless::Vec<u8, MAX_MSG_LENGTH>;
 
 pub trait RawPacketExt {
     fn packet_len(&self) -> usize;
@@ -94,7 +94,7 @@ impl core::fmt::Debug for DataBlock<'_> {
         ;
 
             let l = core::cmp::min(self.data.len(), 16);
-        let escaped_bytes: heapless::Vec<u8, heapless::consts::U64> =
+        let escaped_bytes: heapless::Vec<u8, 64> =
             self.data.iter().take(l)
                 .flat_map(|byte| core::ascii::escape_default(*byte))
                 .collect();
@@ -342,7 +342,7 @@ impl core::fmt::Debug for Command {
         match self {
             Command::XfrBlock(block) => {
                 let l = core::cmp::min(self.len(), 8);
-                let escaped_bytes: heapless::Vec<u8, heapless::consts::U64> =
+                let escaped_bytes: heapless::Vec<u8, 64> =
                     block.data().iter().take(l)
                         .flat_map(|byte| core::ascii::escape_default(*byte))
                         .collect();

--- a/components/usbd-ctaphid/Cargo.toml
+++ b/components/usbd-ctaphid/Cargo.toml
@@ -6,10 +6,10 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 
 [dependencies]
-embedded-time = "0.10.1"
+embedded-time = "0.12"
 delog = "0.1.0"
-heapless = "0.6"
-heapless-bytes = "0.2.0"
+heapless = "0.7"
+heapless-bytes = "0.3"
 interchange = "0.2.0"
 serde = { version = "1.0", default-features = false }
 usb-device = "0.2.3"

--- a/components/usbd-ctaphid/src/pipe.rs
+++ b/components/usbd-ctaphid/src/pipe.rs
@@ -474,7 +474,7 @@ impl<'alloc, Bus: UsbBus> Pipe<'alloc, Bus> {
                     self.interchange.take_response();
                 }
                 match self.interchange.request(
-                    &(request.command, heapless_bytes::Bytes::try_from_slice(&self.buffer[..request.length as usize]).unwrap())
+                    &(request.command, heapless::Vec::from_slice(&self.buffer[..request.length as usize]).unwrap())
                 ) {
                     Ok(_) => {
                         self.state = State::WaitingOnAuthenticator(request);

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -5,7 +5,7 @@ name = "runner"
 version = "0.1.1"
 authors = ["Nicolas Stalder <n@stalder.io>", "Conor Patrick <conor@solokeys.com>"]
 edition = "2018"
-# resolver = "2"
+resolver = "2"
 
 [lib]
 name = "runner"
@@ -55,7 +55,7 @@ panic-halt = "0.2.0"
 # panic-semihosting = "0.5.6"
 
 # storage
-littlefs2 = "0.2.2"
+littlefs2 = "0.3.1"
 
 [features]
 default = ["admin-app", "fido-authenticator", "ndef-app", "oath-authenticator", "piv-authenticator", "trussed/clients-4"]

--- a/runners/lpc55/board/Cargo.toml
+++ b/runners/lpc55/board/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 delog = "0.1.0"
 fm11nc08 = {path = "../../../components/fm11nc08"}
-lpc55-hal = { version = "0.2.1", features = ["littlefs", "rtic-peripherals"] }
+lpc55-hal = { version = "0.3", features = ["littlefs", "rtic-peripherals"] }
 nb = "1"
 trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main" }
 

--- a/runners/lpc55/src/types.rs
+++ b/runners/lpc55/src/types.rs
@@ -4,10 +4,9 @@ use core::convert::TryInto;
 use crate::hal;
 use hal::drivers::timer;
 use interchange::Interchange;
-use littlefs2::const_ram_storage;
+use littlefs2::{const_ram_storage, consts};
 use trussed::types::{LfsResult, LfsStorage};
 use trussed::{platform, store};
-use ctap_types::consts;
 use hal::peripherals::ctimer;
 
 #[cfg(feature = "no-encrypted-storage")]
@@ -109,7 +108,7 @@ impl admin_app::Reboot for Lpc55Reboot {
 #[cfg(feature = "admin-app")]
 pub type AdminApp = admin_app::App<TrussedClient, Lpc55Reboot>;
 #[cfg(feature = "piv-authenticator")]
-pub type PivApp = piv_authenticator::Authenticator<apdu_dispatch::command::Size, TrussedClient>;
+pub type PivApp = piv_authenticator::Authenticator<TrussedClient, {apdu_dispatch::command::SIZE}>;
 #[cfg(feature = "oath-authenticator")]
 pub type OathApp = oath_authenticator::Authenticator<TrussedClient>;
 #[cfg(feature = "fido-authenticator")]
@@ -119,7 +118,7 @@ pub type NdefApp = ndef_app::App<'static>;
 #[cfg(feature = "provisioner-app")]
 pub type ProvisionerApp = provisioner_app::Provisioner<Store, FlashStorage, TrussedClient>;
 
-use apdu_dispatch::{App as ApduApp, command::Size as CommandSize, response::Size as ResponseSize};
+use apdu_dispatch::{App as ApduApp, command::SIZE as CommandSize, response::SIZE as ResponseSize};
 use ctaphid_dispatch::app::{App as CtaphidApp};
 
 pub type DynamicClockController = board::clock_controller::DynamicClockController;

--- a/runners/lpc55/src/types/usb.rs
+++ b/runners/lpc55/src/types/usb.rs
@@ -9,7 +9,7 @@ pub type EnabledUsbPeripheral = hal::peripherals::usbfs::EnabledUsbfsDevice;
 pub type CcidClass = usbd_ccid::Ccid<
     UsbBus<EnabledUsbPeripheral>,
     apdu_dispatch::interchanges::Contact,
-    apdu_dispatch::interchanges::Size,
+    {apdu_dispatch::interchanges::SIZE},
 >;
 pub type CtapHidClass = usbd_ctaphid::CtapHid<'static, UsbBus<EnabledUsbPeripheral>>;
 // pub type KeyboardClass = usbd_hid::hid_class::HIDClass<'static, UsbBus<EnabledUsbPeripheral>>;

--- a/runners/pc/Cargo.toml
+++ b/runners/pc/Cargo.toml
@@ -30,7 +30,7 @@ admin-app = {path = "./../../components/admin-app"}
 dispatch-fido = {path = "./../../components/dispatch-fido"}
 
 # storage
-littlefs2 = "0.2.1"
+littlefs2 = "0.3.1"
 
 [features]
 default = []

--- a/runners/pc/src/bin/main.rs
+++ b/runners/pc/src/bin/main.rs
@@ -1,8 +1,6 @@
 use std::{fs::File, io::Write};
 pub use embedded_hal::blocking::rng;
-use littlefs2::{
-    const_ram_storage,
-};
+use littlefs2::{const_ram_storage, consts};
 use littlefs2::fs::{Allocation, Filesystem};
 use trussed::types::{LfsResult, LfsStorage};
 
@@ -12,7 +10,6 @@ use trussed::platform::{
     consent,
 };
 use trussed::{platform, store};
-use ctap_types::consts;
 
 pub use generic_array::{
     GenericArray,
@@ -73,10 +70,6 @@ impl littlefs2::driver::Storage for FileFlash {
 
     type CACHE_SIZE = littlefs_params::CACHE_SIZE;
     type LOOKAHEADWORDS_SIZE = littlefs_params::LOOKAHEADWORDS_SIZE;
-    type FILENAME_MAX_PLUS_ONE = littlefs_params::FILENAME_MAX_PLUS_ONE;
-    type PATH_MAX_PLUS_ONE = littlefs_params::PATH_MAX_PLUS_ONE;
-    const FILEBYTES_MAX: usize = littlefs_params::FILEBYTES_MAX;
-    type ATTRBYTES_MAX = littlefs_params::ATTRBYTES_MAX;
 
 
     fn read(&self, off: usize, buf: &mut [u8]) -> LfsResult<usize> {


### PR DESCRIPTION
The aim of this exercise was to get generic-array out of the "type" crates, such as iso7816 and ctap-types.

It's not quite complete, as
- littlefs2 needs generic-array (maybe) due to const-generics limitations (maybe as might be fixed otherwise, by changing how "drivers" are configured)
- some external dependencies pull in heapless 0.6 still.