### PR TITLE
Remove --enable-machine-outliner=never LLVM arg

### DIFF
--- a/runners/lpc55/.cargo/config
+++ b/runners/lpc55/.cargo/config
@@ -3,7 +3,6 @@ runner = "arm-none-eabi-gdb -q -x jlink.gdb"
 rustflags = [
   "-C", "linker=flip-link",
   "-C", "link-arg=-Tlink.x",
-  "-C", "llvm-args=--enable-machine-outliner=never",
   # "-Dwarnings",
 ]
 


### PR DESCRIPTION
Rust 1.53.0 automatically sets the --enable-machine-outliner=never LLVM
argument [0] [1].  As we also set this option in
runners/lpc55/.cargo/config, we currently get a compliation error.  This
patch removes the option from our cargo configuration to fix the build.

[0] https://github.com/rust-lang/rust/commit/c63a1c0a1b40ee4567fb91a606a542cbbc55a856
[1] https://github.com/rust-lang/rust/pull/86020