### PR TITLE
provisioner-app: Remove unused filesystem constant

### DIFF
--- a/components/provisioner-app/src/lib.rs
+++ b/components/provisioner-app/src/lib.rs
@@ -18,8 +18,6 @@ use core::convert::TryFrom;
 
 use trussed::types::LfsStorage;
 
-pub const FILESYSTEM_BOUNDARY: usize = 0x8_0000;
-
 use littlefs2::path::{PathBuf};
 use trussed::store::{self, Store};
 use trussed::{


### PR DESCRIPTION
The FILESYSTEM_BOUNDARY constant in the provisioner app is currently
unused.  The actual filesystem boundaries are defined in the build.rs
file.  To make the code easier to understand and to avoid confusion,
this patch removes the unused constant.