### PR TITLE
only send keepalive ctaphid messages while handling cbor messages

### DIFF
--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "runner"
-version = "1.0.8"
+version = "1.0.9"
 authors = ["Nicolas Stalder <n@stalder.io>", "Conor Patrick <conor@solokeys.com>"]
 edition = "2018"
 resolver = "2"


### PR DESCRIPTION
Fixes issue on windows where requests would occasionally error out with "This security key cannot be used".